### PR TITLE
eng/PR-77 Restrict carrier DB editing to admins for now

### DIFF
--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -1260,7 +1260,7 @@ async def search_for_commodity(ctx, lookfor):
 
 
 @bot.command(name='carrier_edit', help='Edit a specific carrier in the database by providing specific inputs')
-@commands.has_role('Carrier Owner')
+@commands.has_role('Admin')
 async def edit_carrier(ctx, carrier_name):
     """
     Edits a carriers information in the database. Provide a carrier name that can be partially matched and follow the

--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -1270,7 +1270,15 @@ async def edit_carrier(ctx, carrier_name):
     :param str carrier_name: The carrier name to find
     :returns: None
     """
-    print(f'edit_carrier called by {ctx.author} to update the carrier: {carrier_name}')
+    print(f'edit_carrier called by {ctx.author} to update the carrier: {carrier_name} from channel: {ctx.channel}')
+
+    # make sure we are in the right channel
+    bot_command_channel = bot.get_channel(conf['BOT_COMMAND_CHANNEL'])
+    current_channel = ctx.channel
+    if current_channel != bot_command_channel:
+        # problem, wrong channel, no progress
+        return await ctx.send(f'Sorry, you can only run this command out of: {bot_command_channel}.')
+
     # Go fetch the carrier details by searching for the name
 
     carrier_data = copy.copy(find_carrier_from_long_name(carrier_name))

--- a/constants.py
+++ b/constants.py
@@ -5,6 +5,7 @@ PROD_FLAIR_MISSION_STOP = "eea2d818-9235-11eb-b86f-0e50eec082f5"
 PROD_TRADE_ALERTS_ID = 801798469189763073  # trade alerts channel ID for PTN main server
 PROD_SUB_REDDIT = "PilotsTradeNetwork"  # subreddit for live
 PROD_CHANNEL_UPVOTES = 828279034387103744    # The ID for the updoots channel
+PROD_BOT_COMMAND_CHANNEL = 802523724674891826   # Bot backend commands are locked to a channel
 
 # Testing variables
 
@@ -15,6 +16,7 @@ TEST_FLAIR_MISSION_STOP = "4242a2e2-8e8e-11eb-b443-0e664851dbff"
 TEST_TRADE_ALERTS_ID = 824383348628783144  # trade alerts channel ID for PTN test server
 TEST_SUB_REDDIT = "PTNBotTesting"  # subreddit for testing
 TEST_CHANNEL_UPVOTES = 839918504676294666    # The ID for the updoots channel on test
+TEST_BOT_COMMAND_CHANNEL = 842152343441375283   # Bot backend commands are locked to a channel
 
 EMBED_COLOUR_LOADING = 0x80ffff         # blue
 EMBED_COLOUR_UNLOADING = 0x80ff80       # green
@@ -42,15 +44,17 @@ def get_constant(production: bool):
             'MISSION_STOP': PROD_FLAIR_MISSION_STOP,
             'SUB_REDDIT': PROD_SUB_REDDIT,
             'TRADE_ALERTS_ID': PROD_TRADE_ALERTS_ID,
-            'CHANNEL_UPVOTES': PROD_CHANNEL_UPVOTES
+            'CHANNEL_UPVOTES': PROD_CHANNEL_UPVOTES,
+            'BOT_COMMAND_CHANNEL': PROD_BOT_COMMAND_CHANNEL
         }
     else:
         result = {
-                'MISSION_START': TEST_FLAIR_MISSION_START,
-                'MISSION_STOP': TEST_FLAIR_MISSION_STOP,
-                'SUB_REDDIT': TEST_SUB_REDDIT,
-                'TRADE_ALERTS_ID': TEST_TRADE_ALERTS_ID,
-                'CHANNEL_UPVOTES': TEST_CHANNEL_UPVOTES
-            }
+            'MISSION_START': TEST_FLAIR_MISSION_START,
+            'MISSION_STOP': TEST_FLAIR_MISSION_STOP,
+            'SUB_REDDIT': TEST_SUB_REDDIT,
+            'TRADE_ALERTS_ID': TEST_TRADE_ALERTS_ID,
+            'CHANNEL_UPVOTES': TEST_CHANNEL_UPVOTES,
+            'BOT_COMMAND_CHANNEL': TEST_BOT_COMMAND_CHANNEL
+        }
 
     return result

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,6 +1,6 @@
 from constants import get_constant, PROD_FLAIR_MISSION_START, PROD_FLAIR_MISSION_STOP, PROD_TRADE_ALERTS_ID, \
     PROD_SUB_REDDIT, TEST_FLAIR_MISSION_START, TEST_FLAIR_MISSION_STOP, TEST_TRADE_ALERTS_ID, TEST_SUB_REDDIT, \
-    PROD_CHANNEL_UPVOTES, TEST_CHANNEL_UPVOTES
+    PROD_CHANNEL_UPVOTES, TEST_CHANNEL_UPVOTES, PROD_BOT_COMMAND_CHANNEL, TEST_BOT_COMMAND_CHANNEL
 
 
 def test_production_values():
@@ -13,6 +13,7 @@ def test_production_values():
     assert config['TRADE_ALERTS_ID'] is PROD_TRADE_ALERTS_ID
     assert config['SUB_REDDIT'] is PROD_SUB_REDDIT
     assert config['CHANNEL_UPVOTES'] is PROD_CHANNEL_UPVOTES
+    assert config['BOT_COMMAND_CHANNEL'] is PROD_BOT_COMMAND_CHANNEL
 
 
 def test_testing_server_values():
@@ -25,3 +26,4 @@ def test_testing_server_values():
     assert config['TRADE_ALERTS_ID'] is TEST_TRADE_ALERTS_ID
     assert config['SUB_REDDIT'] is TEST_SUB_REDDIT
     assert config['CHANNEL_UPVOTES'] is TEST_CHANNEL_UPVOTES
+    assert config['BOT_COMMAND_CHANNEL'] is TEST_BOT_COMMAND_CHANNEL


### PR DESCRIPTION
Change carrier_edit to Admin role.
Change carrier_edit to use the bot-commands channel

Fixes: #77 