### PR TITLE
Updated help texts, updated m.find, added emoji reaction to updoots post

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -6,9 +6,10 @@ PROD_DISCORD_GUILD = 800080948716503040 # PTN Discord server
 PROD_TRADE_ALERTS_ID = 801798469189763073  # trade alerts channel ID for PTN main server
 PROD_SUB_REDDIT = "PilotsTradeNetwork"  # subreddit for live
 PROD_CHANNEL_UPVOTES = 828279034387103744    # The ID for the updoots channel
+PROD_MISSION_CHANNEL = 822603169104265276    # The ID for the production mission channel
 PROD_BOT_COMMAND_CHANNEL = 802523724674891826   # Bot backend commands are locked to a channel
 PROD_BOT_SPAM_CHANNEL = 801258393205604372 # Certain bot logging messages go here
-PROD_MISSION_CHANNEL = 822603169104265276    # The ID for the production mission channel
+PROD_UPVOTE_EMOJI = 828287733227192403 # upvote emoji on live server
 
 # Testing variables
 
@@ -23,6 +24,7 @@ TEST_CHANNEL_UPVOTES = 839918504676294666    # The ID for the updoots channel on
 TEST_MISSION_CHANNEL = 842138710651961364    # The ID for the production mission channel
 TEST_BOT_COMMAND_CHANNEL = 842152343441375283   # Bot backend commands are locked to a channel
 TEST_BOT_SPAM_CHANNEL = 842525081858867211 # Bot logging messages on the test server
+TEST_UPVOTE_EMOJI = 849388681382068225 # upvote emoji on test server
 
 EMBED_COLOUR_LOADING = 0x80ffff         # blue
 EMBED_COLOUR_UNLOADING = 0x80ff80       # green
@@ -55,7 +57,8 @@ def get_constant(production: bool):
             'CHANNEL_UPVOTES': PROD_CHANNEL_UPVOTES,
             'MISSION_CHANNEL': PROD_MISSION_CHANNEL,
             'BOT_COMMAND_CHANNEL': PROD_BOT_COMMAND_CHANNEL,
-            'BOT_SPAM_CHANNEL': PROD_BOT_SPAM_CHANNEL
+            'BOT_SPAM_CHANNEL': PROD_BOT_SPAM_CHANNEL,
+            'UPVOTE_EMOJI': PROD_UPVOTE_EMOJI
         }
     else:
         result = {
@@ -67,7 +70,8 @@ def get_constant(production: bool):
             'CHANNEL_UPVOTES': TEST_CHANNEL_UPVOTES,
             'MISSION_CHANNEL': TEST_MISSION_CHANNEL,
             'BOT_COMMAND_CHANNEL': TEST_BOT_COMMAND_CHANNEL,
-            'BOT_SPAM_CHANNEL': TEST_BOT_SPAM_CHANNEL
+            'BOT_SPAM_CHANNEL': TEST_BOT_SPAM_CHANNEL,
+            'UPVOTE_EMOJI': TEST_UPVOTE_EMOJI
         }
 
     return result


### PR DESCRIPTION
Fixes #167 

Also fixes that issue I apparently didn't open after all about updating seriously out of date help texts, in particular:
- removing references to shortname from commands that don't use them
- specifying in all slash command descriptions that they are private

The updoots post now adds an upvote emoji that users can click on rather than having to add it themselves.

Also did some housekeeping by renaming internal variables: lookname etc are now more descriptive e.g. carrier_name_search_term, commodity_search_term etc

Finally m.find now copes with multiple matches, however I ran into the same problem I assume @gcruicks did when implementing this which is that a whole bunch of features depend on the find function returning just one result and I didn't have the gumption to transform them to all use the "select which carrier you want" code so I was a naughty boy and added a temporary find_multiple function used purely by m.find. This can become the new find function when the old one is deprecated.