### PR TITLE
#169: Post wine loads to booze cruise category

### DIFF
--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -742,14 +742,6 @@ async def gen_mission(ctx, carrier_name_search_term, commodity_search_term, syst
     embed.set_footer(text="Enter all that apply, e.g. **drn** will send alerts to Discord and Reddit and notify your crew.")
     message_confirm = await ctx.send(embed=embed)
 
-    
-    #Wine load guard, bool for altering behaviour dependent on whether carrier is loading wine
-    #(should there be one for an unloading?)
-    wineFlag = False
-    if commodity_data.name.Title() == "Wine":
-        wineFlag = True
-    
-    #TODO: Apply any additional desired behaviour via the wine flag
     try:
         msg = await bot.wait_for("message", check=check_confirm, timeout=30)
 
@@ -799,7 +791,7 @@ async def gen_mission(ctx, carrier_name_search_term, commodity_search_term, syst
             message_send = await ctx.send("**Sending to Discord...**")
 
             # send trade alert to trade alerts channel, or to wine alerts channel if loading wine
-            if wineFlag:
+            if commodity_data.name.Title() == "Wine":
                 channel = bot.get_channel(wine_alerts_id)
                 channelId = wine_alerts_id
             else:

--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -743,11 +743,13 @@ async def gen_mission(ctx, carrier_name_search_term, commodity_search_term, syst
     message_confirm = await ctx.send(embed=embed)
 
     
-    # TODO: WINE CATCH STATEMENT
+    #Wine load guard, bool for altering behaviour dependent on whether carrier is loading wine
+    #(should there be one for an unloading?)
     wineFlag = False
     if commodity_data.name.Title() == "Wine":
         wineFlag = True
-
+    
+    #TODO: Apply any additional desired behaviour via the wine flag
     try:
         msg = await bot.wait_for("message", check=check_confirm, timeout=30)
 
@@ -759,7 +761,6 @@ async def gen_mission(ctx, carrier_name_search_term, commodity_search_term, syst
             return
 
         if "t" in msg.content.lower():
-            #TODO: apply wine flag adjustments
             embed = discord.Embed(title="Trade Alert (Discord)", description=f"`{discord_text}`",
                                   color=constants.EMBED_COLOUR_DISCORD)
             await ctx.send(embed=embed)

--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -55,6 +55,7 @@ flair_mission_stop = conf['MISSION_STOP']
 
 # channel IDs
 trade_alerts_id = conf['TRADE_ALERTS_ID']
+wine_alerts_id = conf['WINE_ALERTS_ID']
 bot_spam_id = conf['BOT_SPAM_CHANNEL']
 to_subreddit = conf['SUB_REDDIT']
 
@@ -741,6 +742,12 @@ async def gen_mission(ctx, carrier_name_search_term, commodity_search_term, syst
     embed.set_footer(text="Enter all that apply, e.g. **drn** will send alerts to Discord and Reddit and notify your crew.")
     message_confirm = await ctx.send(embed=embed)
 
+    
+    # TODO: WINE CATCH STATEMENT
+    wineFlag = False
+    if commodity_data.name.Title() == "Wine":
+        wineFlag = True
+
     try:
         msg = await bot.wait_for("message", check=check_confirm, timeout=30)
 
@@ -752,7 +759,7 @@ async def gen_mission(ctx, carrier_name_search_term, commodity_search_term, syst
             return
 
         if "t" in msg.content.lower():
-
+            #TODO: apply wine flag adjustments
             embed = discord.Embed(title="Trade Alert (Discord)", description=f"`{discord_text}`",
                                   color=constants.EMBED_COLOUR_DISCORD)
             await ctx.send(embed=embed)
@@ -787,10 +794,16 @@ async def gen_mission(ctx, carrier_name_search_term, commodity_search_term, syst
             await ctx.send(embed=embed)
 
         if "d" in msg.content.lower():
+            #TODO: apply wine flag adjustments
             message_send = await ctx.send("**Sending to Discord...**")
 
-            # send trade alert to trade alerts channel
-            channel = bot.get_channel(trade_alerts_id)
+            # send trade alert to trade alerts channel, or to wine alerts channel if loading wine
+            if wineFlag:
+                channel = bot.get_channel(wine_alerts_id)
+                channelId = wine_alerts_id
+            else:
+                channel = bot.get_channel(trade_alerts_id)
+                channelId = trade_alerts_id
 
             if mission_type == 'load':
                 embed = discord.Embed(description=discord_text, color=constants.EMBED_COLOUR_LOADING)
@@ -819,18 +832,17 @@ async def gen_mission(ctx, carrier_name_search_term, commodity_search_term, syst
                      "will show all current trade missions\nUse /crew to join or leave this carrier's crew")
             await channel.send(file=discord_file, embed=embed)
             embed = discord.Embed(title=f"Discord trade alerts sent for {carrier_data.carrier_long_name}",
-                                  description=f"Check <#{trade_alerts_id}> for trade alert and "
+                                  description=f"Check <#{channelId}> for trade alert and "
                                               f"<#{carrier_data.channel_id}> for image.",
                                   color=constants.EMBED_COLOUR_DISCORD)
             await ctx.send(embed=embed)
             await message_send.delete()
 
         if "r" in msg.content.lower():
-
             if int(profit) < 10:
                 print(f'Not posting the mission from {ctx.author} to reddit due to low profit margin <10k/t.')
                 await ctx.send(f'Skipped Reddit posting due to profit margin of {profit}k/t being below the PTN 10k/t '
-                               f'minimum.')
+                               f'minimum. (Did you try to post a Wine load?)')
             else:
                 message_send = await ctx.send("**Sending to Reddit...**")
 

--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -787,17 +787,16 @@ async def gen_mission(ctx, carrier_name_search_term, commodity_search_term, syst
             await ctx.send(embed=embed)
 
         if "d" in msg.content.lower():
-            #TODO: apply wine flag adjustments
             message_send = await ctx.send("**Sending to Discord...**")
 
             # send trade alert to trade alerts channel, or to wine alerts channel if loading wine
-            if commodity_data.name.Title() == "Wine":
+            if commodity_data.name.title() == "Wine":
                 channel = bot.get_channel(wine_alerts_id)
                 channelId = wine_alerts_id
             else:
                 channel = bot.get_channel(trade_alerts_id)
                 channelId = trade_alerts_id
-
+                
             if mission_type == 'load':
                 embed = discord.Embed(description=discord_text, color=constants.EMBED_COLOUR_LOADING)
             else:
@@ -876,10 +875,10 @@ async def gen_mission(ctx, carrier_name_search_term, commodity_search_term, syst
                         description=f"Pinged <@&{carrier_data.roleid}> in <#{carrier_data.channel_id}>",
                         color=constants.EMBED_COLOUR_DISCORD)
             await ctx.send(embed=embed)
-
     except asyncio.TimeoutError:
         await ctx.send("**Mission not generated or broadcast (no valid response from user).**")
         return
+
 
     # now clear up by deleting the prompt message and user response
     await msg.delete()

--- a/constants.py
+++ b/constants.py
@@ -20,7 +20,7 @@ TEST_FLAIR_MISSION_STOP = "4242a2e2-8e8e-11eb-b443-0e664851dbff"
 
 TEST_DISCORD_GUILD = 818174236480897055 # test Discord server
 TEST_TRADE_ALERTS_ID = 843252609057423361  # trade alerts channel ID for PTN test server
-TEST_WINE_ALERTS_ID = 843252609057423361 # currently this ID is the same as that of Test Trade Alert
+TEST_WINE_ALERTS_ID = 848492679079395371 # currently this ID is the testing channel in the test server
 TEST_SUB_REDDIT = "PTNBotTesting"  # subreddit for testing
 TEST_CHANNEL_UPVOTES = 839918504676294666    # The ID for the updoots channel on test
 TEST_MISSION_CHANNEL = 842138710651961364    # The ID for the production mission channel

--- a/constants.py
+++ b/constants.py
@@ -4,6 +4,7 @@ PROD_FLAIR_MISSION_STOP = "eea2d818-9235-11eb-b86f-0e50eec082f5"
 
 PROD_DISCORD_GUILD = 800080948716503040 # PTN Discord server
 PROD_TRADE_ALERTS_ID = 801798469189763073  # trade alerts channel ID for PTN main server
+PROD_WINE_ALERTS_ID = 0000 #TODO: get ID for #booze-cruise-loading-operations
 PROD_SUB_REDDIT = "PilotsTradeNetwork"  # subreddit for live
 PROD_CHANNEL_UPVOTES = 828279034387103744    # The ID for the updoots channel
 PROD_MISSION_CHANNEL = 822603169104265276    # The ID for the production mission channel
@@ -19,6 +20,7 @@ TEST_FLAIR_MISSION_STOP = "4242a2e2-8e8e-11eb-b443-0e664851dbff"
 
 TEST_DISCORD_GUILD = 818174236480897055 # test Discord server
 TEST_TRADE_ALERTS_ID = 843252609057423361  # trade alerts channel ID for PTN test server
+TEST_WINE_ALERTS_ID = 0000 #TODO: get ID for #booze-cruise-loading-operations on test server
 TEST_SUB_REDDIT = "PTNBotTesting"  # subreddit for testing
 TEST_CHANNEL_UPVOTES = 839918504676294666    # The ID for the updoots channel on test
 TEST_MISSION_CHANNEL = 842138710651961364    # The ID for the production mission channel
@@ -54,6 +56,7 @@ def get_constant(production: bool):
             'BOT_GUILD': PROD_DISCORD_GUILD,
             'SUB_REDDIT': PROD_SUB_REDDIT,
             'TRADE_ALERTS_ID': PROD_TRADE_ALERTS_ID,
+            'WINE_ALERTS_ID' : PROD_WINE_ALERTS_ID,
             'CHANNEL_UPVOTES': PROD_CHANNEL_UPVOTES,
             'MISSION_CHANNEL': PROD_MISSION_CHANNEL,
             'BOT_COMMAND_CHANNEL': PROD_BOT_COMMAND_CHANNEL,
@@ -67,6 +70,7 @@ def get_constant(production: bool):
             'BOT_GUILD': TEST_DISCORD_GUILD,
             'SUB_REDDIT': TEST_SUB_REDDIT,
             'TRADE_ALERTS_ID': TEST_TRADE_ALERTS_ID,
+            'WINE_ALERTS_ID' : TEST_WINE_ALERTS_ID,
             'CHANNEL_UPVOTES': TEST_CHANNEL_UPVOTES,
             'MISSION_CHANNEL': TEST_MISSION_CHANNEL,
             'BOT_COMMAND_CHANNEL': TEST_BOT_COMMAND_CHANNEL,

--- a/constants.py
+++ b/constants.py
@@ -4,7 +4,7 @@ PROD_FLAIR_MISSION_STOP = "eea2d818-9235-11eb-b86f-0e50eec082f5"
 
 PROD_DISCORD_GUILD = 800080948716503040 # PTN Discord server
 PROD_TRADE_ALERTS_ID = 801798469189763073  # trade alerts channel ID for PTN main server
-PROD_WINE_ALERTS_ID = 0000 #TODO: get ID for #booze-cruise-loading-operations
+PROD_WINE_ALERTS_ID = 853596290460811265 # booze alerts channel ID for PTN main server
 PROD_SUB_REDDIT = "PilotsTradeNetwork"  # subreddit for live
 PROD_CHANNEL_UPVOTES = 828279034387103744    # The ID for the updoots channel
 PROD_MISSION_CHANNEL = 822603169104265276    # The ID for the production mission channel
@@ -20,7 +20,7 @@ TEST_FLAIR_MISSION_STOP = "4242a2e2-8e8e-11eb-b443-0e664851dbff"
 
 TEST_DISCORD_GUILD = 818174236480897055 # test Discord server
 TEST_TRADE_ALERTS_ID = 843252609057423361  # trade alerts channel ID for PTN test server
-TEST_WINE_ALERTS_ID = 0000 #TODO: get ID for #booze-cruise-loading-operations on test server
+TEST_WINE_ALERTS_ID = 843252609057423361 # currently this ID is the same as that of Test Trade Alert
 TEST_SUB_REDDIT = "PTNBotTesting"  # subreddit for testing
 TEST_CHANNEL_UPVOTES = 839918504676294666    # The ID for the updoots channel on test
 TEST_MISSION_CHANNEL = 842138710651961364    # The ID for the production mission channel


### PR DESCRIPTION
Channel IDs for wine load alerts still needed for resolution to be final (I don't have access to these)
Use of a bool to implement slightly mission-posting different behavior in the event of a wine-load, checked by identifying the commodity
Message CMDR Bear_Grylls on Discord for queries/concerns

Fixes #169 