### PR TITLE
Create carrier channels on the fly for missions

### DIFF
--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -5,7 +5,6 @@
 # Discord Developer Portal: https://discord.com/developers/applications/822146046934384640/information
 # Git repo: https://github.com/PilotsTradeNetwork/MissionAlertBot
 import ast
-from asyncio.windows_events import NULL
 import copy
 import tempfile
 from itertools import islice

--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -67,8 +67,8 @@ hauler_role_id = conf['HAULER_ROLE']
 upvote_emoji = conf['UPVOTE_EMOJI']
 
 # channel removal timers
-seconds_short = 20
-seconds_long = 20
+seconds_short = 120
+seconds_long = 900
 
 # Get the discord token from the local .env file. Deliberately not hosted in the repo or Discord takes the bot down
 # because the keys are exposed. DO NOT HOST IN THE REPO. Seriously do not do it ...

--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -168,7 +168,7 @@ if not check_database_table_exists('missions', mission_db):
             CREATE TABLE missions(
                 "carrier"	TEXT NOT NULL UNIQUE,
                 "cid"	TEXT,
-                "channelid"	INTEGER,
+                "channelid"	INT,
                 "commodity"	TEXT,
                 "missiontype"	TEXT,
                 "system"	TEXT NOT NULL,
@@ -181,8 +181,7 @@ if not check_database_table_exists('missions', mission_db):
                 "reddit_post_url"	TEXT,
                 "reddit_comment_id"	TEXT,
                 "reddit_comment_url"	TEXT,
-                "discord_alert_id"	INT,
-                "mission_channel_id"	INT
+                "discord_alert_id"	INT
             )
         ''')
 else:


### PR DESCRIPTION
Closes #183

Tested fairly thoroughly, should be working on existing carrier.db (i.e. the post crew-roles change version) - just ignores the channelid column now. Should also work with existing instances of mission.db

Note that carrier_edit still allows users to change the now unused channelid field.

I don't know why line 8 is showing an additional import, I didn't change that.