### PR TITLE
Add last trade tracking, cron task, task status command 'cron_status'

### DIFF
--- a/CarrierData.py
+++ b/CarrierData.py
@@ -43,7 +43,7 @@ class CarrierData:
         return 'CarrierData: CarrierLongName:{0.carrier_long_name} CarrierShortName:{0.carrier_short_name} ' \
                'CarrierIdentifier:{0.carrier_identifier} DiscordChannel:{0.discord_channel} ' \
                'DiscordChannelID:{0.channel_id} ' \
-               'OwnerID:{0.ownerid} CarrierPid:{0.pid}'.format(self)
+               'OwnerID:{0.ownerid} CarrierPid:{0.pid} LastTrade:{0.lasttrade}'.format(self)
 
     def __bool__(self):
         """

--- a/CarrierData.py
+++ b/CarrierData.py
@@ -18,6 +18,7 @@ class CarrierData:
         self.discord_channel = info_dict.get('discordchannel', None)
         self.channel_id = info_dict.get('channelid', None)
         self.ownerid = info_dict.get('ownerid', None)
+        self.lasttrade = info_dict.get('lasttrade', None)
         self.pid = info_dict.get('p_ID', None)
 
     def to_dictionary(self):

--- a/constants.py
+++ b/constants.py
@@ -17,6 +17,8 @@ PROD_UPVOTE_EMOJI = 828287733227192403 # upvote emoji on live server
 PROD_HAULER_ROLE = 875313960834965544 # hauler role ID on live server
 PROD_CC_ROLE = 869340261057196072 # CC role on live server
 PROD_CC_CAT = 877107894452117544 # Community Carrier category on live server
+PROD_CERTCARRIER_ROLE = 947253075561824327 # Certified Carrier role on live server
+PROD_RESCARRIER_ROLE = 947253075561824327 # Fleet Reserve Carrier role on live server
 PROD_TRADE_CAT = 801558838414409738 # Trade Carrier category on live server
 PROD_ARCHIVE_CAT = 821542402836660284 # Archive category on live server
 PROD_SECONDS_SHORT = 120
@@ -43,6 +45,8 @@ TEST_UPVOTE_EMOJI = 849388681382068225 # upvote emoji on test server
 TEST_HAULER_ROLE = 875439909102575647 # hauler role ID on test server
 TEST_CC_ROLE = 877220476827619399 # CC role on test server
 TEST_CC_CAT = 877108931699310592 # Community Carrier category on test server
+TEST_CERTCARRIER_ROLE = 947519773925859370 # Certified Carrier role on test server
+TEST_RESCARRIER_ROLE = 947521000122249247 # Fleet Reserve Carrier role on test server
 TEST_TRADE_CAT = 876569219259580436 # Trade Carrier category on live server
 TEST_ARCHIVE_CAT = 877244591579992144 # Archive category on live server
 TEST_SECONDS_SHORT = 5
@@ -88,6 +92,8 @@ def get_constant(production: bool):
             'HAULER_ROLE' : PROD_HAULER_ROLE,
             'CC_ROLE' : PROD_CC_ROLE,
             'CC_CAT' : PROD_CC_CAT,
+            'CERTCARRIER_ROLE' : PROD_CERTCARRIER_ROLE,
+            'RESCARRIER_ROLE' : PROD_RESCARRIER_ROLE,
             'TRADE_CAT' : PROD_TRADE_CAT,
             'ARCHIVE_CAT' : PROD_ARCHIVE_CAT,
             'SECONDS_SHORT' : PROD_SECONDS_SHORT,
@@ -112,6 +118,8 @@ def get_constant(production: bool):
             'HAULER_ROLE' : TEST_HAULER_ROLE,
             'CC_ROLE' : TEST_CC_ROLE,
             'CC_CAT' : TEST_CC_CAT,
+            'CERTCARRIER_ROLE' : TEST_CERTCARRIER_ROLE,
+            'RESCARRIER_ROLE' : TEST_RESCARRIER_ROLE,
             'TRADE_CAT' : TEST_TRADE_CAT,
             'ARCHIVE_CAT' : TEST_ARCHIVE_CAT,
             'SECONDS_SHORT' : TEST_SECONDS_SHORT,


### PR DESCRIPTION
Upon next run of the bot with this PR, a new carriers table will be created with the 'lasttraded' column.

Data from the previous table will be copied over (this is done so sqlite obeys the column DEFAULT - see comments in code). A backup table will be created first in case anything goes wrong.

New carriers added will have lasttrade set to now().

New missions will update lasttrade column to now().

A discordpy background task on a 24 hour loop will evaluate carriers with lastrade < 28 days, altering roles as required.

A new command 'cron_status' has been added to restart or display next run time of the task.

Note: I could not run MAB on my local env, but I tested as much of this code as I could inside the PTN Stock Bot.