### PR TITLE
update info command, add owner of trade message

### DIFF
--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -1330,8 +1330,9 @@ async def gen_mission(ctx, carrier_name_search_term: str, commodity_search_term:
                                         description=f">>> {rp_text}" if rp else "", color=embed_colour)
 
                     embed.add_field(name="Destination", value=f"Station: {station.upper()}\nSystem: {system.upper()}", inline=True)
+                    embed.add_field(name="Carrier Owner", value=f"<@{carrier_data.ownerid}>")
                     if eta:
-                        embed.add_field(name="ETA", value=f"{eta} minutes", inline=True)
+                        embed.add_field(name="ETA", value=f"{eta} minutes", inline=False)
 
                     embed.set_image(url="attachment://image.png")
                     embed.set_footer(
@@ -1345,12 +1346,6 @@ async def gen_mission(ctx, carrier_name_search_term: str, commodity_search_term:
                                         color=constants.EMBED_COLOUR_DISCORD)
                     await ctx.send(embed=embed)
                     await message_send.delete()
-
-                    #send and then edit the message to avoid actually pinging the owner
-                    owner_msg = "This Trade Mission is run by"
-                    user_message = await mission_temp_channel.send(owner_msg)
-                    await user_message.edit(content=f"{owner_msg} <@{carrier_data.ownerid}>")
-
                     submit_mission = True
                 except Exception as e:
                     print(f"Error sending to Discord: {e}")

--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -1345,6 +1345,12 @@ async def gen_mission(ctx, carrier_name_search_term: str, commodity_search_term:
                                         color=constants.EMBED_COLOUR_DISCORD)
                     await ctx.send(embed=embed)
                     await message_send.delete()
+
+                    #send and then edit the message to avoid actually pinging the owner
+                    owner_msg = "This Trade Mission is run by"
+                    user_message = await mission_temp_channel.send(owner_msg)
+                    await user_message.edit(content=f"{owner_msg} <@{carrier_data.ownerid}>")
+
                     submit_mission = True
                 except Exception as e:
                     print(f"Error sending to Discord: {e}")
@@ -2200,7 +2206,12 @@ async def _info(ctx: SlashContext):
         print(f'Found data: {carrier_data}')
         embed = discord.Embed(title=f"Welcome to {carrier_data.carrier_long_name} ({carrier_data.carrier_identifier})", color=constants.EMBED_COLOUR_OK)
         embed = _add_common_embed_fields(embed, carrier_data, ctx)
-        return await ctx.send(embed=embed, hidden=True)
+        carrier_owner_obj = bot.get_user(carrier_data.ownerid)
+        thumbnail_file = discord.File(f"images/{carrier_data.carrier_short_name}.png", filename="image.png")
+        embed.set_thumbnail(url="attachment://image.png")
+        embed.set_author(name=carrier_owner_obj.name, icon_url=carrier_owner_obj.avatar_url)
+        ctx.author = carrier_owner_obj
+        return await ctx.send(file=thumbnail_file, embed=embed, hidden=True)
 
 
 @slash.slash(name="find", guild_ids=[bot_guild_id],


### PR DESCRIPTION
1. Update `/info` based off #351 (as far as I can tell the bullet point for the trade alerts message is already done
**OLD**
![old_info](https://user-images.githubusercontent.com/6210395/200132734-e700e6b7-bb11-480f-aa35-e6b13b6182b2.png)
**NEW**
![new_info](https://user-images.githubusercontent.com/6210395/200132744-ca6d1a5c-9c46-4d0f-bbbc-644876a0b3e2.png)


2. Send a message to the trade channel of who the carrier owner is (edit so it doesn't ping) #393 
![runby](https://user-images.githubusercontent.com/6210395/200132758-5148460c-76fa-4fe2-89f5-c07dd9e86a1d.png)
