### PR TITLE
Fix column mapping for lasttrade_cron

### DIFF
--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -2022,7 +2022,7 @@ async def _cleanup_completed_mission(ctx, mission_data, reddit_complete_text, di
                         alert_channel = bot.get_channel(wine_alerts_unloading_id)
                 else:
                     alert_channel = bot.get_channel(trade_alerts_id)
-                
+
                 discord_alert_id = mission_data.discord_alert_id
 
                 try: # shitty hacky message of incorporating legacy trades without extra DB fields
@@ -4246,7 +4246,7 @@ async def lasttrade_cron():
         # get carriers who last traded >28 days ago
         # for owners with multiple carriers look at only the most recently used
         carrier_db.execute(f'''
-                            SELECT p_ID,shortname,ownerid,max(lasttrade)
+                            SELECT p_ID,shortname,ownerid,max(lasttrade) as lasttrade
                             FROM carriers WHERE lasttrade < {int(lasttrade_max.timestamp())}
                             GROUP BY ownerid
                             ''')


### PR DESCRIPTION
When we query the database for the lasttrade of a carrier we are using the following query
```
SELECT p_ID,shortname,ownerid,max(lasttrade)
FROM carriers WHERE lasttrade < {int(lasttrade_max.timestamp())}
GROUP BY ownerid
```
This is returning the data to look like
```
p_ID: 11111
shortname: abcdefg
ownerid: 23123123123
max(lasttrade): 1234556677
```

The issue here is we are assigning the lasttrade to the name of `max(lasttrade)`. We then build a CarrierData object from this.
Which in turn looks for a key named `lasttrade` but all we find is `max(lasttrade)` so we are assigned lasttrade to `None`, which then breaks when we try to convert that into a timestamp
```
        self.lasttrade = info_dict.get('lasttrade', None)
```

Just assign `max(lasttrade)` in the sql query to `lasttrade`