### PR TITLE
redo the query to consider all the trades correctly

### DIFF
--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -4232,7 +4232,6 @@ async def stopquit(ctx):
 # If not already present, add 'Fleet Reserve' role to the owner.
 @tasks.loop(hours=24)
 async def lasttrade_cron():
-    return
     print(f"last trade cron running.")
     try:
         # get roles
@@ -4247,9 +4246,10 @@ async def lasttrade_cron():
         # get carriers who last traded >28 days ago
         # for owners with multiple carriers look at only the most recently used
         carrier_db.execute(f'''
-                            SELECT p_ID,shortname,ownerid,max(lasttrade) as lasttrade
-                            FROM carriers WHERE lasttrade < {int(lasttrade_max.timestamp())}
-                            GROUP BY ownerid
+                            SELECT p_ID, shortname, ownerid, lasttrade
+                            FROM carriers c1
+                            WHERE lasttrade = (SELECT MAX(lasttrade) FROM carriers c2 WHERE c1.ownerid = c2.ownerid)
+                            and lasttrade < {int(lasttrade_max.timestamp())}
                             ''')
         carriers = [CarrierData(carrier) for carrier in carrier_db.fetchall()]
         for carrier_data in carriers:


### PR DESCRIPTION
Let us understand what happened!

TLDR: We were asking for the MAX() trade that was less than a given timestamp, even if they had trades that were greater than

Our original query
```
SELECT p_ID,shortname,ownerid,max(lasttrade) as lasttrade
FROM carriers WHERE lasttrade < {int(lasttrade_max.timestamp())}
GROUP BY ownerid
```
Using the following example carriers on the test discord:
```
221|one|CARRIER_ONE|TA4-GH9|carrier_one|0|194649021669834752|1
222|two|CARRIER_TWO|TA4-GH9|carrier_two|0|194649021669834752|1
223|three|CARRIER_THREE|TA4-GH3|carrier_three|0|194649021669834752|5
224|simone|SIM_ONE|TA4-SM1|sim_one|0|211891698551226368|10
225|simtwo|SIM_TWO|TA4-SM2|sim_two|0|211891698551226368|12
```

The last value in each line is the lasttrade. So that would be `1,1,5` for skiedudes carriers and `10,12` for sims carriers

Our query was saying show me if any carriers from every owner have a lasttrade that is `<` the given timestamp **even if they have some that aren't**. So if I put `WHERE lasttrade < 4` I would return
`222|two|CARRIER_TWO|TA4-GH9|carrier_two|0|194649021669834752|1` even though I have a carrier with a value of 5. 

**The new query**
```
SELECT p_ID, shortname, ownerid, lasttrade
FROM carriers c1
WHERE lasttrade = (SELECT MAX(lasttrade) FROM carriers c2 WHERE c1.ownerid = c2.ownerid)
and lasttrade < {int(lasttrade_max.timestamp())}
```

This looks very similar with the main magic being `WHERE lasttrade = (SELECT MAX(lasttrade) FROM carriers c2 WHERE c1.ownerid = c2.ownerid)`

In this case, we are querying the carriers table in a subquery and getting the MAX(lasttrade) regardless of anything we want to compare it to. Just give me the max(lasttrade) per ownerid
THEN we compare that separately queried lasttrade against our special timestamp. Using the same test data above and using this query:

```
SELECT p_ID, shortname, ownerid, lasttrade
FROM carriers c1
WHERE lasttrade = (SELECT MAX(lasttrade) FROM carriers c2 WHERE c1.ownerid = c2.ownerid)
and lasttrade < 4
...
no results
```
As expected no results. Even though skiedude has 2/3 trades that are less than 4, there is one trade that is > 4, which is what lasttrade is being set to (5). 