### PR TITLE
/carrier_edit, checking correct channel, no nominating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ missions.db.backup
 backup/
 __pycache__/
 images/cc/
-db_sql/
+db_sql/*.sql
 .idea
 
 .env

--- a/CarrierData.py
+++ b/CarrierData.py
@@ -53,3 +53,9 @@ class CarrierData:
         :rtype: bool
         """
         return any([value for key, value in vars(self).items() if value])
+
+    def __eq__(self, other):
+        """
+        When comparing two CarrierData class objects, compare them as dicts
+        """
+        return self.__dict__ == other.__dict__

--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -3059,7 +3059,10 @@ async def _carrier_edit(interaction: discord.Interaction, carrier_name_search_te
     orig_carrier_data = copy.copy(carrier_data)
     print(carrier_data)
     if carrier_data:
+        embed = discord.Embed(title="Original Carrier Data", color=discord.Color.green())
+        embed = await _configure_all_carrier_detail_embed(embed, carrier_data)
         return await interaction.response.send_message(
+            embed=embed,
             view=CarrierEditView(carrier_data=carrier_data,orig_carrier_data=orig_carrier_data), ephemeral=True)
     else:
         embed = discord.Embed(title=f'No result found for the carrier: "{carrier_name_search_term}"', color=constants.EMBED_COLOUR_ERROR)
@@ -3092,7 +3095,7 @@ class CarrierEditView(discord.ui.View):
             self.stop()
             return await interaction.response.edit_message(content=None, embed=embed, view=None)
         else:
-            embed = discord.Embed(title="Review the Data!", color=discord.Color.orange())
+            embed = discord.Embed(title="Review Carrier Changes", color=discord.Color.orange())
             embed = await _configure_all_carrier_detail_embed(embed, self.carrier_data)
             await interaction.response.edit_message(
                 content=None,

--- a/MissionAlertBot.py
+++ b/MissionAlertBot.py
@@ -84,6 +84,7 @@ cmentor_role_id = conf['CMENTOR_ROLE']
 certcarrier_role_id = conf['CERTCARRIER_ROLE']
 rescarrier_role_id = conf['RESCARRIER_ROLE']
 botadmin_role_id = conf['ADMIN_ROLE']
+mod_role_id = conf['MOD_ROLE']
 trainee_role_id = conf['TRAINEE_ROLE']
 botdev_role_id = conf['DEV_ROLE']
 any_elevated_role = [cc_role_id, cmentor_role_id, certcarrier_role_id, rescarrier_role_id, botadmin_role_id, trainee_role_id, botdev_role_id]
@@ -245,29 +246,6 @@ def check_database_table_exists(table_name, database):
     database.execute(f"SELECT count(name) FROM sqlite_master WHERE TYPE = 'table' AND name = '{table_name}'")
     return bool(database.fetchone()[0])
 
-def create_missing_table(table, db_obj, create_stmt):
-    print(f'{table} table missing - creating it now')
-
-    if os.path.exists(os.path.join(os.getcwd(), 'db_sql', f'{table}_dump.sql')):
-
-        # recreate from backup file
-        print('Recreating database from backup ...')
-        with open(os.path.join(os.getcwd(), 'db_sql', f'{table}_dump.sql')) as f:
-
-            sql_script = f.read()
-            db_obj.executescript(sql_script)
-
-
-        # print('Loaded the following data: ')
-        # carrier_db.execute('''SELECT * from carriers ''')
-        # for e in carrier_db.fetchall():
-        #     print(f'\t {CarrierData(e)}')
-    else:
-        # Create a new version
-        print('No backup found - Creating empty database')
-
-        db_obj.execute(create_stmt)
-
 
 def check_table_column_exists(column_name, table_name, database):
     """
@@ -351,7 +329,7 @@ database_table_map = {
 for table_name in database_table_map:
     t = database_table_map[table_name]
     if not check_database_table_exists(table_name, t['obj']):
-        create_missing_table(table_name, t['obj'], t['create'])
+        t['obj'].execute(t['create'])
     else:
         print(f'{table_name} table exists, do nothing')
 
@@ -391,31 +369,6 @@ for column_name in new_column_map:
         print(f'{column_name} exists, do nothing')
 
 
-def dump_database_test(database_name):
-    """
-    Dumps the database object to a .sql text file while backing up the database. Used just to get something we can
-    recreate the database from.  This will only store the last state and should periodically be committed to the repo
-    from the bot.
-
-    :param str database_name: The DB name to connect against.
-    :returns: None
-    :raises ValueError: if the db name is unknown
-    """
-    # We only have 2 databases today, carriers and missions, though this could really just be 2 tables in a single
-    # database at some stage.
-
-    if database_name == 'missions':
-        connection = missions_conn
-    elif database_name == 'carriers':
-        connection = carriers_conn
-    else:
-        raise ValueError(f'Unknown DB dump handling for: {database_name}')
-
-    with open(f'db_sql/{database_name}_dump.sql', 'w') as f:
-        for line in connection.iterdump():
-            f.write(line)
-
-
 # function to backup carrier database
 def backup_database(database_name):
     """
@@ -431,7 +384,6 @@ def backup_database(database_name):
 
     shutil.copy(f'{database_name}.db', f'backup/{database_name}.{dt_file_string}.db')
     print(f'Backed up {database_name}.db at {dt_file_string}')
-    dump_database_test(database_name)
 
 
 # function to add carrier, being sure to correct case
@@ -915,7 +867,10 @@ def getrole(ctx, id): # takes a Discord role ID and returns the role object
     role = discord.utils.get(ctx.guild.roles, id=id)
     return role
 
-async def checkroles(ctx, permitted_role_ids): # checks a list of roles against a user's roles
+async def checkroles(ctx, permitted_role_ids):
+    """
+    Check if the user has at least one of the permitted roles to run a command
+    """
     try: # hacky way to make this work with both slash and normal commands
         author_roles = ctx.author.roles
     except: # slash commands use interaction instead of ctx and user instead of author
@@ -940,11 +895,46 @@ async def checkroles(ctx, permitted_role_ids): # checks a list of roles against 
     return permission
 
 def check_roles(permitted_role_ids):
+    """
+    Decorator used on a normal or slash command to enforce the command
+    can only be users with a specific role(s)
+    """
     def decorator(function):
         @wraps(function)
         async def wrapper(*args, **kwargs):
             permission = await checkroles(args[0], permitted_role_ids)
             if permission:
+                return await function(*args, **kwargs)
+            else:
+                return
+        return wrapper
+    return decorator
+
+
+async def check_channel(ctx, permitted_channel):
+    """
+    Check if the channel the command was run in, matches the channel it can only be run from
+    """
+    permitted = bot.get_channel(permitted_channel)
+    if ctx.channel != permitted:
+        # problem, wrong channel, no progress
+        embed=discord.Embed(description=f"Sorry, you can only run this command out of: {permitted}.", color=constants.EMBED_COLOUR_ERROR)
+        await ctx.channel.send(embed=embed) if hasattr(ctx, 'author') else await ctx.response.send_message(embed=embed, ephemeral=True)
+        return False
+    else:
+        return True
+
+
+def check_command_channel(permitted_channel):
+    """
+    Decorator used on a normal or slash command to enforce the command
+    can only be run in specific channels
+    """
+    def decorator(function):
+        @wraps(function)
+        async def wrapper(*args, **kwargs):
+            correct_channel = await check_channel(args[0], permitted_channel)
+            if correct_channel:
                 return await function(*args, **kwargs)
             else:
                 return
@@ -1018,7 +1008,6 @@ async def on_ready():
     except Exception as e:
         print(f"Tree sync failed: {e}.")
 
-    
     # define our background tasks
     reddit_task = asyncio.create_task(_monitor_reddit_comments())
     # Check if any trade channels were not deleted before bot restart/stop
@@ -1116,6 +1105,7 @@ async def _monitor_reddit_comments():
                                'ETA is optional and should be expressed as a number of minutes e.g. 15.\n'
                                'Case is automatically corrected for all inputs.')
 @check_roles([certcarrier_role_id, trainee_role_id])
+@check_command_channel(conf['MISSION_CHANNEL'])
 async def load(ctx, carrier_name_search_term: str, commodity_search_term: str, system: str, station: str,
                profit: Union[int, float], pads: str, demand: str, eta: str = None):
     rp = False
@@ -1130,6 +1120,7 @@ async def load(ctx, carrier_name_search_term: str, commodity_search_term: str, s
                                  'and sent to the carrier\'s Discord channel in quote format if those options are '
                                  'chosen')
 @check_roles([certcarrier_role_id, trainee_role_id])
+@check_command_channel(conf['MISSION_CHANNEL'])
 async def loadrp(ctx, carrier_name_search_term: str, commodity_search_term: str, system: str, station: str,
                  profit: Union[int, float], pads: str, demand: str, eta: str = None):
     rp = True
@@ -1151,6 +1142,7 @@ async def loadrp(ctx, carrier_name_search_term: str, commodity_search_term: str,
                                'ETA is optional and should be expressed as a number of minutes e.g. 15.\n'
                                'Case is automatically corrected for all inputs.')
 @check_roles([certcarrier_role_id, trainee_role_id])
+@check_command_channel(conf['MISSION_CHANNEL'])
 async def loadlegacy(ctx, carrier_name_search_term: str, commodity_search_term: str, system: str, station: str,
                profit: Union[int, float], pads: str, demand: str, eta: str = None):
     rp = False
@@ -1165,6 +1157,7 @@ async def loadlegacy(ctx, carrier_name_search_term: str, commodity_search_term: 
                                  'and sent to the carrier\'s Discord channel in quote format if those options are '
                                  'chosen')
 @check_roles([certcarrier_role_id, trainee_role_id])
+@check_command_channel(conf['MISSION_CHANNEL'])
 async def loadrplegacy(ctx, carrier_name_search_term: str, commodity_search_term: str, system: str, station: str,
                  profit: Union[int, float], pads: str, demand: str, eta: str = None):
     rp = True
@@ -1185,6 +1178,7 @@ async def loadrplegacy(ctx, carrier_name_search_term: str, commodity_search_term
                                  'ETA is optional and should be expressed as a number of minutes e.g. 15.\n'
                                  'Case is automatically corrected for all inputs.')
 @check_roles([certcarrier_role_id, trainee_role_id])
+@check_command_channel(conf['MISSION_CHANNEL'])
 async def unload(ctx, carrier_name_search_term: str, commodity_search_term: str, system: str, station: str,
                  profit: Union[int, float], pads: str, supply: str, eta: str = None):
     rp = False
@@ -1199,6 +1193,7 @@ async def unload(ctx, carrier_name_search_term: str, commodity_search_term: str,
                                    'and sent to the carrier\'s Discord channel in quote format if those options are '
                                    'chosen')
 @check_roles([certcarrier_role_id, trainee_role_id])
+@check_command_channel(conf['MISSION_CHANNEL'])
 async def unloadrp(ctx, carrier_name_search_term: str, commodity_search_term: str, system: str, station: str,
                    profit: Union[int, float], pads: str, demand: str, eta: str = None):
 
@@ -1220,6 +1215,7 @@ async def unloadrp(ctx, carrier_name_search_term: str, commodity_search_term: st
                                  'ETA is optional and should be expressed as a number of minutes e.g. 15.\n'
                                  'Case is automatically corrected for all inputs.')
 @check_roles([certcarrier_role_id, trainee_role_id])
+@check_command_channel(conf['MISSION_CHANNEL'])
 async def unload(ctx, carrier_name_search_term: str, commodity_search_term: str, system: str, station: str,
                  profit: Union[int, float], pads: str, supply: str, eta: str = None):
     rp = False
@@ -1234,6 +1230,7 @@ async def unload(ctx, carrier_name_search_term: str, commodity_search_term: str,
                                    'and sent to the carrier\'s Discord channel in quote format if those options are '
                                    'chosen')
 @check_roles([certcarrier_role_id, trainee_role_id])
+@check_command_channel(conf['MISSION_CHANNEL'])
 async def unloadrp(ctx, carrier_name_search_term: str, commodity_search_term: str, system: str, station: str,
                    profit: Union[int, float], pads: str, demand: str, eta: str = None):
     rp = True
@@ -1247,16 +1244,11 @@ async def unloadrp(ctx, carrier_name_search_term: str, commodity_search_term: st
 async def gen_mission(ctx, carrier_name_search_term: str, commodity_search_term: str, system: str, station: str,
                       profit: Union[int, float], pads: str, demand: str, rp: str, mission_type: str,
                       eta: str, legacy):
-    # Check we are in the designated mission channel, if not go no farther.
-    mission_gen_channel = bot.get_channel(conf['MISSION_CHANNEL'])
     current_channel = ctx.channel
 
     print(f'Mission generation type: {mission_type} with RP: {rp}, requested by {ctx.author}. Request triggered from '
           f'channel {current_channel}.')
 
-    if current_channel != mission_gen_channel:
-        # problem, wrong channel, no progress
-        return await ctx.send(f'Sorry, you can only run this command out of: {mission_gen_channel}.')
     if pads.upper() not in ['M', 'L']:
         # In case a user provides some junk for pads size, gate it
         print(f'Exiting mission generation requested by {ctx.author} as pad size is invalid, provided: {pads}')
@@ -1981,18 +1973,13 @@ async def _missions(interaction: discord.Interaction):
                                'appropriate.\n\nAnything after the carrier name will be treated as a '
                                'quote to be sent along with the completion notice. This can be used for RP if desired.')
 @check_roles([certcarrier_role_id, trainee_role_id, rescarrier_role_id])
+@check_command_channel(conf['MISSION_CHANNEL'])
 async def done(ctx, carrier_name_search_term: str, *, rp: str = None):
 
-    # Check we are in the designated mission channel, if not go no farther.
-    mission_gen_channel = bot.get_channel(conf['MISSION_CHANNEL'])
     current_channel = ctx.channel
 
     print(f'Request received from {ctx.author} to mark the mission of {carrier_name_search_term} as done from channel: '
           f'{current_channel}')
-
-    if current_channel != mission_gen_channel:
-        # problem, wrong channel, no progress
-        return await ctx.send(f'Sorry, you can only run this command out of: <#{mission_gen_channel.id}>.')
 
     mission_data = find_mission(carrier_name_search_term, "carrier")
     if not mission_data:
@@ -2323,15 +2310,8 @@ async def complete(ctx, comment: str = None):
 # backup databases
 @bot.command(name='backup', help='Backs up the carrier and mission databases.')
 @check_roles([botadmin_role_id])
+@check_command_channel(conf['BOT_COMMAND_CHANNEL'])
 async def backup(ctx):
-
-    # make sure we are in the right channel
-    bot_command_channel = bot.get_channel(conf['BOT_COMMAND_CHANNEL'])
-    current_channel = ctx.channel
-    if current_channel != bot_command_channel:
-        # problem, wrong channel, no progress
-        return await ctx.send(f'Sorry, you can only run this command out of: {bot_command_channel}.')
-
     print(f"{ctx.author} requested a manual DB backup")
     backup_database('missions')
     backup_database('carriers')
@@ -2522,14 +2502,8 @@ async def carrier_list(ctx):
                                       '<carrier_id> is the carrier\'s unique identifier in the format ABC-XYZ\n'
                                       '<owner_id> is the owner\'s Discord ID')
 @check_roles([botadmin_role_id])
+@check_command_channel(conf['BOT_COMMAND_CHANNEL'])
 async def carrier_add(ctx, short_name: str, long_name: str, carrier_id: str, owner_id: int):
-
-    # make sure we are in the right channel
-    bot_command_channel = bot.get_channel(conf['BOT_COMMAND_CHANNEL'])
-    current_channel = ctx.channel
-    if current_channel != bot_command_channel:
-        # problem, wrong channel, no progress
-        return await ctx.send(f'Sorry, you can only run this command out of: {bot_command_channel}.')
 
     # check the ID code is correct format (thanks boozebot code!)
     if not re.match(r"\w{3}-\w{3}", carrier_id):
@@ -2542,7 +2516,7 @@ async def carrier_add(ctx, short_name: str, long_name: str, carrier_id: str, own
         # Carrier exists already, go skip it.
         print(f'Request recieved from {ctx.author} to add a carrier that already exists in the database ({long_name}).')
 
-        embed = discord.Embed(title="Fleet carrier already exists, use m.carrier_edit to change its details.",
+        embed = discord.Embed(title="Fleet carrier already exists, use /carrier_edit to change its details.",
                               description=f"Carrier data matched for {long_name}", color=constants.EMBED_COLOUR_OK)
         embed = _add_common_embed_fields(embed, carrier_data, ctx)
         return await ctx.send(embed=embed)
@@ -2573,15 +2547,8 @@ async def carrier_add(ctx, short_name: str, long_name: str, carrier_id: str, own
 # remove FC from database
 @bot.command(name='carrier_del', help='Delete a Fleet Carrier from the database using its database entry ID#.')
 @check_roles([botadmin_role_id])
+@check_command_channel(conf['BOT_COMMAND_CHANNEL'])
 async def carrier_del(ctx, db_id: int):
-
-    # make sure we are in the right channel
-    bot_command_channel = bot.get_channel(conf['BOT_COMMAND_CHANNEL'])
-    current_channel = ctx.channel
-    if current_channel != bot_command_channel:
-        # problem, wrong channel, no progress
-        return await ctx.send(f'Sorry, you can only run this command out of: {bot_command_channel}.')
-
     try:
         carrier_data = find_carrier(db_id, CarrierDbFields.p_id.name)
         if carrier_data:
@@ -3071,123 +3038,189 @@ async def search_for_commodity(ctx, commodity_search_term: str):
     await ctx.send(f'No such commodity found for: "{commodity_search_term}".')
 
 
-@bot.command(name='carrier_edit', help='Edit a specific carrier in the database by providing specific inputs')
+@bot.tree.command(name="carrier_edit",
+    description="Edit a specific carrier in the database", guild=guild_obj)
 @check_roles([botadmin_role_id])
-async def edit_carrier(ctx, carrier_name_search_term: str):
+@check_command_channel(conf['BOT_COMMAND_CHANNEL'])
+async def _carrier_edit(interaction: discord.Interaction, carrier_name_search_term: str):
     """
     Edits a carriers information in the database. Provide a carrier name that can be partially matched and follow the
     steps.
 
-    :param discord.ext.commands.Context ctx: The discord context
+    :param discord.interaction interaction: The discord interaction
     :param str carrier_name_search_term: The carrier name to find
     :returns: None
     """
-    print(f'edit_carrier called by {ctx.author} to update the carrier: {carrier_name_search_term} from channel: {ctx.channel}')
-
-    # make sure we are in the right channel
-    bot_command_channel = bot.get_channel(conf['BOT_COMMAND_CHANNEL'])
-    current_channel = ctx.channel
-    if current_channel != bot_command_channel:
-        # problem, wrong channel, no progress
-        return await ctx.send(f'Sorry, you can only run this command out of: {bot_command_channel}.')
+    print(f'/carrier_edit called by {interaction.user} to update the carrier: {carrier_name_search_term} from channel: {interaction.channel}')
 
     # Go fetch the carrier details by searching for the name
 
     carrier_data = copy.copy(find_carrier(carrier_name_search_term, CarrierDbFields.longname.name))
+    orig_carrier_data = copy.copy(carrier_data)
     print(carrier_data)
     if carrier_data:
-        embed = discord.Embed(title=f"Edit DB request received.",
-                              description=f"Editing starting for {carrier_data.carrier_long_name} requested by "
-                                          f"{ctx.author}",
-                              color=constants.EMBED_COLOUR_OK)
-        embed = _configure_all_carrier_detail_embed(embed, carrier_data)
+        return await interaction.response.send_message(
+            view=CarrierEditView(carrier_data=carrier_data,orig_carrier_data=orig_carrier_data), ephemeral=True)
+    else:
+        embed = discord.Embed(title=f'No result found for the carrier: "{carrier_name_search_term}"', color=constants.EMBED_COLOUR_ERROR)
+        return await interaction.response.send_message(embed=embed)
 
-        # Store this, we might want to update it later
-        initial_message = await ctx.send(embed=embed)
-        edit_carrier_data = await _determine_db_fields_to_edit(ctx, carrier_data)
-        if not edit_carrier_data:
-            # The determination told the user there was an error. Wipe the original message and move on
-            initial_message.delete()
-            return
 
-        # Now we know what fields to edit, go do something with them, first display them to the user
-        edited_embed = discord.Embed(title=f"Please validate the inputs are correct",
-                                     description=f"Validate the new settings for {carrier_data.carrier_long_name}",
-                                     color=constants.EMBED_COLOUR_OK)
-        edited_embed = _configure_all_carrier_detail_embed(edited_embed, edit_carrier_data)
-        edit_send = await ctx.send(embed=edited_embed)
+class CarrierEditView(discord.ui.View):
+    """
+    Main trade view containing the:
+        select menu, station|system modal, trade data modal
+    If self.data is not set, create a dict with default keys set to ''
+    """
+    def __init__(self, carrier_data, orig_carrier_data):
+        self.carrier_data = carrier_data
+        self.orig_carrier_data = orig_carrier_data
+        super().__init__()
 
-        # Get the user to agree before we write
-        confirm_embed = discord.Embed(title="Confirm you want to write these values to the database please",
-                                      description="Yes or No.", color=constants.EMBED_COLOUR_QU)
-        confirm_embed.set_footer(text='y/n - yes, no.')
-        message_confirm = await ctx.send(embed=confirm_embed)
+    @discord.ui.button(label="Name|ID|ShortName", row=1, custom_id='name_id')
+    async def name_callback(self, interaction, button):
+        await interaction.response.send_modal(CarrierNameIDModal(title='Carrier Name | ID | ShortName', view=self))
 
-        def check_confirm(message):
-            return message.content and message.author == ctx.author and message.channel == ctx.channel and \
-                   all(character in 'yn' for character in set(message.content.lower())) and len(message.content) == 1
+    @discord.ui.button(label="Channel|Owner|LastTrade", row=1, custom_id='discord_data')
+    async def discord_callback(self, interaction, button):
+        await interaction.response.send_modal(CarrierDiscordDataModal(title='Channel | Owner | LastTrade', view=self))
 
-        try:
+    @discord.ui.button(label="Update Carrier", row=2, custom_id='update', style=discord.ButtonStyle.green)
+    async def update_callback(self, interaction, button):
+        if self.carrier_data == self.orig_carrier_data:
+            embed = discord.Embed(title="No Edits made", color=constants.EMBED_COLOUR_ERROR)
+            self.stop()
+            return await interaction.response.edit_message(content=None, embed=embed, view=None)
+        else:
+            embed = discord.Embed(title="Review the Data!", color=discord.Color.orange())
+            embed = await _configure_all_carrier_detail_embed(embed, self.carrier_data)
+            await interaction.response.edit_message(
+                content=None,
+                embed=embed,
+                view=CarrierEditConfirmationView(self.carrier_data, self.orig_carrier_data)
+            )
 
-            msg = await bot.wait_for("message", check=check_confirm, timeout=30)
-            if "n" in msg.content.lower():
-                print(f'User {ctx.author} requested to cancel the edit operation.')
-                # immediately stop if there's an x anywhere in the message, even if there are other proper inputs
-                await ctx.send("**Edit operation cancelled by the user.**")
-                await msg.delete()
-                await message_confirm.delete()
-                await edit_send.delete()
-                await initial_message.delete()
-                return None  # Exit the check logic
+    @discord.ui.button(label="Cancel", row=2, custom_id='cancel', style=discord.ButtonStyle.red)
+    async def quit_button_callback(self, interaction, button):
+        embed = discord.Embed(title="Carrier Edit Cancelled", color=constants.EMBED_COLOUR_ERROR)
+        await interaction.response.edit_message(content=None, embed=embed, view=None)
+        print('Carrier Edit cancelled')
+        self.stop()
 
-            elif 'y' in msg.content.lower():
-                await ctx.send("**Writing the values now ...**")
-                await message_confirm.delete()
-                await msg.delete()
-                await edit_send.delete()
-        except asyncio.TimeoutError:
-            await ctx.send("**Write operation from {ctx.author} timed out.**")
-            await edit_send.delete()
-            await message_confirm.delete()
-            await initial_message.delete()
-            return None  # Exit the check logic
 
-        # Go update the details to the database
-        await _update_carrier_details_in_database(ctx, edit_carrier_data, carrier_data.carrier_long_name)
+class CarrierEditConfirmationView(discord.ui.View):
+    """
+    """
+    def __init__(self, carrier_data, orig_carrier_data):
+        self.carrier_data = carrier_data
+        self.orig_carrier_data = orig_carrier_data
+        super().__init__()
 
-        # Double check if we need to edit the carrier shortname, if so then we also need to edit the backup image
-        if edit_carrier_data.carrier_short_name != carrier_data.carrier_short_name:
+    @discord.ui.button(label="Confirm", style=discord.ButtonStyle.green)
+    async def save_button_callback(self, interaction, button):
+        await _update_carrier_details_in_database(self.carrier_data, self.orig_carrier_data.carrier_long_name)
+        print(f'Carrier data now looks like:')
+        print(f'\t Original: {self.orig_carrier_data}')
+        print(f'\t Updated: {self.carrier_data}')
+        if self.carrier_data.carrier_short_name != self.orig_carrier_data.carrier_short_name:
             print('Renaming the carriers image')
             os.rename(
-                f'images/{carrier_data.carrier_short_name}.png',
-                f'images/{edit_carrier_data.carrier_short_name}.png'
+                f'images/{self.orig_carrier_data.carrier_short_name}.png',
+                f'images/{self.carrier_data.carrier_short_name}.png'
             )
-            print(f'Carrier image renamed from: images/{carrier_data.carrier_short_name}.png to '
-                  f'images/{edit_carrier_data.carrier_short_name}.png')
+            print(f'Carrier image renamed from: images/{self.orig_carrier_data.carrier_short_name}.png to '
+                  f'images/{self.carrier_data.carrier_short_name}.png')
 
-        # Go grab the details again, make sure it is correct and display to the user
-        updated_carrier_data = find_carrier(edit_carrier_data.carrier_long_name, CarrierDbFields.longname.name)
+        updated_carrier_data = find_carrier(self.carrier_data.carrier_long_name, CarrierDbFields.longname.name)
         if updated_carrier_data:
             embed = discord.Embed(title=f"Reading the settings from DB:",
                                   description=f"Double check and re-run if incorrect the settings for old name: "
-                                              f"{carrier_data.carrier_long_name}",
+                                              f"{self.orig_carrier_data.carrier_long_name}",
                                   color=constants.EMBED_COLOUR_OK)
-            embed = _configure_all_carrier_detail_embed(embed, updated_carrier_data)
-            await initial_message.delete()
-            return await ctx.send(embed=embed)
-        else:
-            await ctx.send('We did not find the new database entry - that is not good.')
+            embed = await _configure_all_carrier_detail_embed(embed, updated_carrier_data)
+            self.stop()
+            return await interaction.response.edit_message(content=None, view=None, embed=embed)
 
-    else:
-        return await ctx.send(f'No result found for the carrier: "{carrier_name_search_term}".')
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red)
+    async def quit_button_callback(self, interaction, button):
+        embed = discord.Embed(title="Carrier Edit Cancelled", color=constants.EMBED_COLOUR_ERROR)
+        await interaction.response.edit_message(content=None, embed=embed, view=None)
+        print('Carrier Edit cancelled')
+        self.stop()
 
 
-async def _update_carrier_details_in_database(ctx, carrier_data, original_name):
+class CarrierNameIDModal(discord.ui.Modal):
     """
-    Updates the carrier details into the database. It first ensures that the discord channel actually exists, if it
-    does not then you are getting an error back.
+    """
+    def __init__(self, title, view, timeout=None):
+        self.view = view
+        self.longname = discord.ui.TextInput(
+            label = 'Long Name',
+            custom_id = 'long_name',
+            default = self.view.carrier_data.carrier_long_name
+            )
 
-    :param discord.ext.commands.Context ctx: The discord context
+        self.shortname = discord.ui.TextInput(
+            label = 'Short Name',
+            custom_id = 'short_name',
+            default = self.view.carrier_data.carrier_short_name
+            )
+
+        self.cid = discord.ui.TextInput(
+            label = 'Carrier Identifier',
+            custom_id = 'c_id',
+            default = self.view.carrier_data.carrier_identifier
+            )
+        super().__init__(title=title, timeout=timeout)
+        self.add_item(self.longname)
+        self.add_item(self.shortname)
+        self.add_item(self.cid)
+
+    async def on_submit(self, interaction):
+        self.view.carrier_data.carrier_long_name = self.children[0].value.strip().upper()
+        self.view.carrier_data.carrier_short_name = self.children[1].value.strip().lower()
+        self.view.carrier_data.carrier_identifier = self.children[2].value.strip().upper()
+        await interaction.response.edit_message(view=self.view)
+
+
+class CarrierDiscordDataModal(discord.ui.Modal):
+    """
+    """
+    def __init__(self, title, view, timeout=None):
+        self.view = view
+
+        self.discord_channel = discord.ui.TextInput(
+            label = 'Discord Channel',
+            custom_id = 'discord_channel',
+            default = self.view.carrier_data.discord_channel
+            )
+        self.ownerid = discord.ui.TextInput(
+            label = 'Owner ID',
+            custom_id = 'owner_id',
+            default = self.view.carrier_data.ownerid
+            )
+        self.lasttrade = discord.ui.TextInput(
+            label = 'Last Trade',
+            custom_id = 'last_trade',
+            default = self.view.carrier_data.lasttrade
+            )
+        super().__init__(title=title, timeout=timeout)
+        self.add_item(self.discord_channel)
+        self.add_item(self.ownerid)
+        self.add_item(self.lasttrade)
+
+    async def on_submit(self, interaction):
+        self.view.carrier_data.discord_channel = self.children[0].value.strip().lower()
+        self.view.carrier_data.ownerid = self.children[1].value.strip()
+        self.view.carrier_data.lasttrade = self.children[2].value.strip()
+
+        await interaction.response.edit_message(view=self.view)
+
+
+async def _update_carrier_details_in_database(carrier_data, original_name):
+    """
+    Updates the carrier details into the database.
+
     :param CarrierData carrier_data: The carrier data to write
     :param str original_name: The original carrier name, needed so we can find it in the database
     """
@@ -3219,128 +3252,7 @@ async def _update_carrier_details_in_database(ctx, carrier_data, original_name):
         carrier_db_lock.release()
 
 
-async def _determine_db_fields_to_edit(ctx, carrier_data):
-    """
-    Loop through a dummy CarrierData object and see if the user wants to update any of the fields.
-
-    :param discord.ext.commands.Context ctx: The discord context object
-    :param CarrierData carrier_data: The carriers data you want to edit.
-    :returns: A carrier data object to edit into the database
-    :rtype: CarrierData
-    """
-    # We operate and return from this a copy of the object, not the object itself. Else things outside this also get
-    # affected. Because python uses pass by reference, and this is a mutable object, things can go wrong.
-    new_carrier_data = copy.copy(carrier_data)
-
-    embed = discord.Embed(title=f"Edit DB request in progress ...",
-                          description=f"Editing in progress for {carrier_data.carrier_long_name}",
-                          color=constants.EMBED_COLOUR_OK)
-
-    def check_confirm(message):
-        return message.content and message.author == ctx.author and message.channel == ctx.channel and \
-            all(character in 'ynx' for character in set(message.content.lower())) and len(message.content) == 1
-
-    def check_user(message):
-        return message.content and message.author == ctx.author and message.channel == ctx.channel
-
-    # These two are used below, initial value so we can wipe the message out if needed
-    message_confirm = None  # type: discord.Message
-    msg = None  # type: discord.Message
-
-    for field in vars(carrier_data):
-
-        # Remove any pre-existing messages/responses if they were present.
-        if message_confirm:
-            await message_confirm.delete()
-        if msg:
-            await msg.delete()
-
-        if field == 'pid':
-            # We cant edit the DB ID here, so skip over it.
-            # TODO: DB ID uses autoincrement, we probably want our own index if we want to use this.
-            continue
-
-        print(f'Looking to see if the user wants to edit the field {field} for carrier: '
-              f'{carrier_data.carrier_long_name}')
-
-        # Go ask the user for each one if they want to update, and if yes then to what.
-        embed.add_field(name=f'Do you want to update the carriers: "{field}" value?',
-                        value=f'Current Value: "{getattr(carrier_data, field)}"', inline=True)
-        embed.set_footer(text='y/n/x - yes, no or cancel the operation')
-        message_confirm = await ctx.send(embed=embed)
-
-        try:
-            msg = await bot.wait_for("message", check=check_confirm, timeout=30)
-            if "x" in msg.content.lower():
-                print(f'User {ctx.author} requested to cancel the edit operation.')
-                # immediately stop if there's an x anywhere in the message, even if there are other proper inputs
-                await ctx.send("**Edit operation cancelled by the user.**")
-                await msg.delete()
-                await message_confirm.delete()
-                return None  # Exit the check logic
-
-            elif 'n' in msg.content.lower():
-                # Log a message and skip over
-                print(f'User {ctx.author} does not want to edit the field: {field}')
-                # We do not care, just move on
-            elif 'y' in msg.content.lower():
-                # Remove this, we re-assign it now.
-                await msg.delete()
-                await message_confirm.delete()
-
-                # Log a message and skip over
-                print(f'User {ctx.author} wants to edit the field: {field}')
-                embed.remove_field(0)   # Remove the current field, add a new one and resend
-
-                embed.add_field(name=f'What is the new value for: {field}?', value='Type your response now.')
-                embed.set_footer()   # Clear the foot as well
-                message_confirm = await ctx.send(embed=embed)
-
-                msg = await bot.wait_for("message", check=check_user, timeout=30)
-                print(f'Setting the value for {new_carrier_data.carrier_long_name} field {field} to '
-                      f'"{msg.content.strip()}"')
-
-                if field in ['carrier_long_name', 'carrier_identifier']:
-                    # always uppercase
-                    msg_content = msg.content.strip().upper()
-                elif field in ['carrier_short_name', 'discord_channel']:
-                    # always lowercase
-                    msg_content = msg.content.strip().lower()
-                else:
-                    # keep user case
-                    msg_content = msg.content.strip()
-
-                # Use setattr to change the value of the variable field object to the user input
-                setattr(new_carrier_data, field, msg_content)
-            else:
-                print(f'{ctx.author} provided the invalid input: {msg.content} from object: {ctx}.')
-                # Should never be hitting this as we gate the message
-                await ctx.send(f"**I cannot do anything with that entry '{msg.content}', please stick to y, n or x.**")
-                return None  # Break condition just in case
-        except asyncio.TimeoutError:
-            print(f'Carrier edit requested by {ctx.author} timed out. Context: {ctx}')
-            await ctx.send("**Edit operation timed out (no valid response from user).**")
-            await message_confirm.delete()
-            return None
-
-        # Remove the previous field so we have things in a nice view
-        embed.remove_field(0)
-
-    print(f'Current tracking of carrier data: {carrier_data}')
-    # If the current thing is the same as the old thing, why did we bother?
-    if new_carrier_data == carrier_data:
-        print(f'User {ctx.author} went through the whole process and does not want to edit anything.')
-        await ctx.send("**After all those button clicks you did not want to edit anything, fun.**")
-        return None
-
-    print(f'Carrier data now looks like:')
-    print(f'\t Original: {carrier_data}')
-    print(f'\t Updated: {new_carrier_data}')
-
-    return new_carrier_data
-
-
-def _configure_all_carrier_detail_embed(embed, carrier_data: CarrierData):
+async def _configure_all_carrier_detail_embed(embed, carrier_data: CarrierData):
     """
     Adds all the common fields to a message embed and returns the embed.
 
@@ -3514,7 +3426,7 @@ async def _create_community_channel(interaction: discord.Interaction, owner: dis
 
     # PROCESS: check for valid emoji
     print(emoji.is_emoji(emoji_string))
-    if not emoji.is_emoji(emoji_string) and not emoji_string == None: 
+    if not emoji.is_emoji(emoji_string) and not emoji_string == None:
         embed = discord.Embed(description="**Error**: Invalid emoji supplied. Use a valid Unicode emoji from your emoji keyboard,"
                                         f"or leave the field blank. **Discord custom emojis will not work**.", color=constants.EMBED_COLOUR_ERROR)
         bu_link = Button(label="Full Emoji List", url="https://unicode.org/emoji/charts/full-emoji-list.html")
@@ -3536,7 +3448,7 @@ async def _create_community_channel(interaction: discord.Interaction, owner: dis
 
     # CHECK: user already owns a channel
     if not await _cc_owner_check(interaction, owner): return
- 
+
     # get the CC category as a discord channel category object
     cc_category = discord.utils.get(interaction.guild.categories, id=cc_cat_id)
     archive_category = discord.utils.get(interaction.guild.categories, id=archive_cat_id)
@@ -3571,7 +3483,7 @@ async def _create_community_channel(interaction: discord.Interaction, owner: dis
     else:
         # channel does not exist, create it
         new_channel = await _cc_create_channel(interaction, new_channel_name, cc_category)
-    
+
     # create the role
     new_role = await _cc_role_create(interaction, new_channel_name)
 
@@ -3771,13 +3683,13 @@ class RemoveCCView(View):
         delete_channel = 1
         print("User wants to delete channel.")
         await _remove_cc_manager(interaction, delete_channel, self)
-        
+
     @discord.ui.button(label="Archive", style=discord.ButtonStyle.primary, emoji="📂", custom_id="archive")
     async def archive_button_callback(self, interaction, button):
         delete_channel = 0
         print("User chose to archive channel.")
         await _remove_cc_manager(interaction, delete_channel, self)
-        
+
         self.clear_items()
         await interaction.response.edit_message(view=self)
         await interaction.delete_original_response()
@@ -3796,7 +3708,7 @@ class RemoveCCView(View):
 @bot.tree.command(name="remove_community_channel",
                   description="Retires a community channel.",
                   guild=guild_obj)
-@check_roles([cmentor_role_id, botadmin_role_id]) 
+@check_roles([cmentor_role_id, botadmin_role_id])
 async def _remove_community_channel(interaction: discord.Interaction):
 
     print(f"{interaction.user.name} called `/remove_community_channel` command in {interaction.channel.name}")
@@ -3851,7 +3763,7 @@ async def _remove_community_channel(interaction: discord.Interaction):
     view = RemoveCCView(author)
 
     await interaction.response.send_message(embed=embed, view=view)
-    
+
     return
 
 # function called by button responses to process channel deletion
@@ -3887,7 +3799,7 @@ async def _remove_cc_manager(interaction, delete_channel, button_self):
     # archive channel if relevant - we save deleting for later so user can read bot status messages in channel
     print("Processing archive flag...")
     if not delete_channel: embed = await _archive_cc_channel(interaction, embed)
-     
+
     # delete role
     print("Deleting role...")
     embed = await _cc_role_delete(interaction, role_id, embed)
@@ -3900,7 +3812,7 @@ async def _remove_cc_manager(interaction, delete_channel, button_self):
 
     # delete channel if relevant
     print("Processing delete flag...")
-    if delete_channel: await _delete_cc_channel(interaction, button_self) 
+    if delete_channel: await _delete_cc_channel(interaction, button_self)
 
     # notify bot-spam
     print("Notifying bot-spam...")
@@ -3956,7 +3868,7 @@ async def _delete_cc_channel(interaction, button_self):
     except Exception as e:
         print(e)
         await interaction.channel.send(f"**Failed to delete <#{interaction.channel.id}>**: {e}")
-    
+
     return
 
 # helper function for /remove_community_channel
@@ -4018,7 +3930,7 @@ async def _openclose_community_channel(interaction, open):
 
     status_text_verb = "open" if open else "close"
     status_text_adj = "open" if open else "closed"
-   
+
     #check we're in the right category
     cc_category = discord.utils.get(interaction.guild.categories, id=cc_cat_id)
     if not interaction.channel.category == cc_category:
@@ -4032,7 +3944,7 @@ async def _openclose_community_channel(interaction, open):
         embed = discord.Embed(description=f"**ERROR**: Could not {status_text_verb} channel: {e}")
         await interaction.response.send_message(embed=embed, ephemeral=True)
         return
-    
+
     # notify user
     embed = discord.Embed(description=f"**<#{interaction.channel.id}> is {status_text_adj}!**"
                                       f"{' This channel is now visble to the server community 😊' if open else f' This channel is now hidden from the server community 😳'}",
@@ -4194,13 +4106,13 @@ async def _generate_cc_notice_embed(channel_id, user, avatar, title, message, im
     thumb_file = None
 
     if os.path.isfile(f"images/cc/{channel_id}.png"):
-        thumb_file = discord.File(f'images/cc/{channel_id}.png', filename='image.png') 
+        thumb_file = discord.File(f'images/cc/{channel_id}.png', filename='image.png')
         print(thumb_file)
 
     embed = discord.Embed(title=title, description=message, color=constants.EMBED_COLOUR_QU)
     embed.set_author(name=user, icon_url=avatar)
     embed.set_image(url=image_url)
-    if thumb_file: embed.set_thumbnail(url='attachment://image.png') 
+    if thumb_file: embed.set_thumbnail(url='attachment://image.png')
     embed.timestamp= datetime.now(tz=timezone.utc)
     embed.set_footer(text="Use \"/notify_me\" in this channel to sign up for future notifications."
                     "\nYou can opt out at any time by using \"/notify_me\" again.")
@@ -4288,7 +4200,7 @@ async def edit_cc_notice(interaction: discord.Interaction, message: discord.Mess
     try: # this to avoid annoying thinking response remaining bug if user cancels on mobile
         await interaction.response.defer()
     finally:
-        return 
+        return
 
 
 # help for Community Channel users. when we refactor we'll work on having proper custom help available in more depth
@@ -4382,6 +4294,16 @@ async def _nominate(interaction: discord.Interaction, user: discord.Member, *, r
         print(f"{interaction.user} tried to nominate themselves for Community Pillar :]")
         return await interaction.response.send_message("You can't nominate yourself! But congrats on the positive self-esteem :)", ephemeral=True)
 
+    #Skip nominating Cpillar|Cmentor|Council|Mod
+    for avoid_role in [cpillar_role_id, cmentor_role_id, botadmin_role_id, mod_role_id]:
+        if user.get_role(avoid_role):
+            print(f"{interaction.user} tried to nominate a Cpillar|Cmentor|Council|Mod : {user.name}")
+            return await interaction.response.send_message(
+                ("You can't nominate an existing Community Pillar,"
+                " Community Mentor, Council or Mod."
+                " But we appreciate your nomination attempt!"),
+                ephemeral=True)
+
     print(f"{interaction.user} wants to nominate {user}")
     spamchannel = bot.get_channel(bot_spam_id)
 
@@ -4467,14 +4389,8 @@ def nom_count_user(pillarid):
 
 @bot.command(name='nom_count', help='Shows all users with more than X nominations')
 @check_roles([cmentor_role_id, botadmin_role_id])
+@check_command_channel(conf['ADMIN_BOT_CHANNEL'])
 async def nom_count(ctx, number: int):
-
-    # make sure we are in the right channel
-    bot_command_channel = bot.get_channel(conf['ADMIN_BOT_CHANNEL'])
-    current_channel = ctx.channel
-    if current_channel != bot_command_channel:
-        # problem, wrong channel, no progress
-        return await ctx.send(f'Sorry, you can only run this command out of: {bot_command_channel}.')
 
     numberint = int(number)
 
@@ -4505,6 +4421,7 @@ async def nom_count(ctx, number: int):
 
 @bot.command(name='nom_details', help='Shows nomination details for given user by ID or @ mention')
 @check_roles([cmentor_role_id, botadmin_role_id])
+@check_command_channel(conf['ADMIN_BOT_CHANNEL'])
 async def nom_details(ctx, userid: Union[discord.Member, int]):
     # userID should really be a discord.Member object, but that lacks a sensible way to cast back to a userid,
     # so just use a string and ignore the problem.
@@ -4522,13 +4439,6 @@ async def nom_details(ctx, userid: Union[discord.Member, int]):
         userid = userid.id  # Actually the ID
 
     print(f"nom_details called by {ctx.author} for member: {member}")
-
-    # make sure we are in the right channel
-    bot_command_channel = bot.get_channel(conf['ADMIN_BOT_CHANNEL'])
-    current_channel = ctx.channel
-    if current_channel != bot_command_channel:
-        # problem, wrong channel, no progress
-        return await ctx.send(f'Sorry, you can only run this command out of: {bot_command_channel}.')
 
     embed=discord.Embed(title=f"Nomination details", description=f"Discord user <@{member.id}>", color=constants.EMBED_COLOUR_OK)
 
@@ -4549,6 +4459,7 @@ async def nom_details(ctx, userid: Union[discord.Member, int]):
 
 @bot.command(name='nom_delete', help='Completely removes all nominations for a user by user ID or @ mention. NOT RECOVERABLE.')
 @check_roles([cmentor_role_id, botadmin_role_id])
+@check_command_channel(conf['ADMIN_BOT_CHANNEL'])
 async def nom_delete(ctx, userid: Union[str, int]):
 
     print(f"nom_delete called by {ctx.author}")
@@ -4567,13 +4478,6 @@ async def nom_delete(ctx, userid: Union[str, int]):
         # if we have a member object, then the member is the userid, and the id is the userid.id ... confused?
         member = userid
         userid = userid.id  # Actually the ID
-
-    # make sure we are in the right channel
-    bot_command_channel = bot.get_channel(conf['ADMIN_BOT_CHANNEL'])
-    current_channel = ctx.channel
-    if current_channel != bot_command_channel:
-        # problem, wrong channel, no progress
-        return await ctx.send(f'Sorry, you can only run this command out of: {bot_command_channel}.')
 
     # check whether user has any nominations
     nominees_data = find_nominee_with_id(userid)

--- a/constants.py
+++ b/constants.py
@@ -26,6 +26,7 @@ PROD_RESCARRIER_ROLE = 929985255903998002 # Fleet Reserve Carrier role on live s
 PROD_TRAINEE_ROLE = 800439864797167637 # CCO Trainee role on live server
 PROD_CPILLAR_ROLE = 863789660425027624 # Community Pillar role on live server
 PROD_DEV_ROLE = 812988180210909214 # Developer role ID on live
+PROD_MOD_ROLE = 813814494563401780 # Mod role ID on Live
 PROD_TRADE_CAT = 801558838414409738 # Trade Carrier category on live server
 PROD_ARCHIVE_CAT = 1048957416781393970 # Archive category on live server
 PROD_SECONDS_SHORT = 120
@@ -55,6 +56,7 @@ TEST_LEGACY_HAULER__ROLE = 1047152762707787786 # legacy hauler role ID on test s
 TEST_CC_ROLE = 877220476827619399 # CC role on test server
 TEST_CC_CAT = 877108931699310592 # Community Carrier category on test server
 TEST_ADMIN_ROLE = 836367194979041351 # Bot Admin role on test server
+TEST_MOD_ROLE = 903292469049974845 # Mod role on test server
 TEST_CMENTOR_ROLE = 877586763672072193 # Community Mentor role on test server
 TEST_CERTCARRIER_ROLE = 822999970012463154 # Certified Carrier role on test server
 TEST_RESCARRIER_ROLE = 947520552766152744 # Fleet Reserve Carrier role on test server
@@ -109,6 +111,7 @@ def get_constant(production: bool):
             'CC_ROLE' : PROD_CC_ROLE,
             'CC_CAT' : PROD_CC_CAT,
             'ADMIN_ROLE' : PROD_ADMIN_ROLE,
+            'MOD_ROLE' : PROD_MOD_ROLE,
             'CMENTOR_ROLE' : PROD_CMENTOR_ROLE,
             'CERTCARRIER_ROLE' : PROD_CERTCARRIER_ROLE,
             'RESCARRIER_ROLE' : PROD_RESCARRIER_ROLE,
@@ -142,6 +145,7 @@ def get_constant(production: bool):
             'CC_ROLE' : TEST_CC_ROLE,
             'CC_CAT' : TEST_CC_CAT,
             'ADMIN_ROLE' : TEST_ADMIN_ROLE,
+            'MOD_ROLE' : TEST_MOD_ROLE,
             'CMENTOR_ROLE' : TEST_CMENTOR_ROLE,
             'CERTCARRIER_ROLE' : TEST_CERTCARRIER_ROLE,
             'RESCARRIER_ROLE' : TEST_RESCARRIER_ROLE,

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ asyncpraw==7.2.0
 asyncprawcore==2.0.1
 python-dateutil>=2.8.1
 discord-py-slash-command>=1.1.2
+emoji>=2.2.0


### PR DESCRIPTION
1. #267 Do not allow nominating anyone in Council, Mod, CMentor, Cpillar (4297-4306)
2. Remove references to the db_sql folder (`create_missing_table` and `dump_database_test`)
3. Add a decorator to replace the `current_channel != desired_channel` for easier use
4. #143 Instead of asking the user which carrier fields they wish to edit, turn this into a slash command that uses views/modals for simple field editing. 
5. Related to 4, remove methods that are no longer in use that were transformed into the new views/modals

See discord for video/picture demo https://discord.com/channels/800080948716503040/827656814911815702/1053903633655287848