### PR TITLE
For Issue #573: Restricting bots from being /nominate

### DIFF
--- a/ptn/missionalertbot/botcommands/GeneralCommands.py
+++ b/ptn/missionalertbot/botcommands/GeneralCommands.py
@@ -22,7 +22,7 @@ from ptn.missionalertbot.classes.Views import MissionCompleteView
 from ptn.missionalertbot._metadata import __version__
 import ptn.missionalertbot.constants as constants
 from ptn.missionalertbot.constants import bot, bot_command_channel, bot_dev_channel, cmentor_role, certcarrier_role, \
-    admin_role, dev_role, trade_alerts_channel, mod_role, cpillar_role, bot_spam_channel
+    admin_role, dev_role, trade_alerts_channel, mod_role, cpillar_role, bot_spam_channel, bot_role
 
 # local modules
 from ptn.missionalertbot.database.database import backup_database, find_carrier, find_mission, _is_carrier_channel, \
@@ -504,13 +504,13 @@ class GeneralCommands(commands.Cog):
             print(f"{interaction.user} tried to nominate themselves for Community Pillar :]")
             return await interaction.response.send_message("You can't nominate yourself! But congrats on the positive self-esteem :)", ephemeral=True)
 
-        #Skip nominating Cpillar|Cmentor|Council|Mod
-        for avoid_role in [cpillar_role(), cmentor_role(), admin_role(), mod_role()]:
+        #Skip nominating Cpillar|Cmentor|Council|Mod|Bot
+        for avoid_role in [cpillar_role(), cmentor_role(), admin_role(), mod_role(), bot_role()]:
             if user.get_role(avoid_role):
                 print(f"{interaction.user} tried to nominate a Cpillar|Cmentor|Council|Mod : {user.name}")
                 return await interaction.response.send_message(
                     (f"You can't nominate an existing <@&{cpillar_role()}>,"
-                    f" <@&{cmentor_role()}>, <@&{admin_role()}> or <@&{mod_role()}>."
+                    f" <@&{cmentor_role()}>, <@&{admin_role()}>, <@&{mod_role()}> or bot."
                     " But we appreciate your nomination attempt!"),
                     ephemeral=True)
 

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -151,6 +151,7 @@ TEST_CPILLAR_ROLE = 903289927184314388 # Community Pillar role on test server
 TEST_DEV_ROLE = 1048913812163678278 # Dev role ID on test
 TEST_VERIFIED_ROLE = 903289848427851847 # Verified Member
 TEST_EVENT_ORGANISER_ROLE = 1121748430650355822 # Event Organiser
+TEST_BOT_ROLE = 842524877051133963 # TestingAlertBot role only - need a generic bot role on test
 TEST_TRADE_CAT = 876569219259580436 # Trade Carrier category on live server
 TEST_ARCHIVE_CAT = 877244591579992144 # Archive category on live server
 TEST_SECONDS_VERY_SHORT = 10 # time between channel deletion trigger and actual deletion
@@ -413,6 +414,9 @@ def verified_role():
 
 def event_organiser_role():
   return PROD_EVENT_ORGANISER_ROLE if _production else TEST_EVENT_ORGANISER_ROLE
+
+def bot_role():
+  return PROD_BOT_ROLE if _production else TEST_BOT_ROLE
 
 def trade_cat():
   return PROD_TRADE_CAT if _production else TEST_TRADE_CAT

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -98,6 +98,7 @@ PROD_DEV_ROLE = 812988180210909214 # Developer role ID on live
 PROD_MOD_ROLE = 813814494563401780 # Mod role ID on Live
 PROD_VERIFIED_ROLE = 867820916331118622 # Verified Member
 PROD_EVENT_ORGANISER_ROLE = 1023296182639939594 # Event Organiser
+PROD_BOT_ROLE = 802523214809923596 # General Bot role on live (Robot Overlords)
 PROD_TRADE_CAT = 801558838414409738 # Trade Carrier category on live server
 PROD_ARCHIVE_CAT = 1048957416781393970 # Archive category on live server
 PROD_SECONDS_VERY_SHORT = 10 # time between channel deletion trigger and actual deletion (10)


### PR DESCRIPTION
- Added both TEST_BOT_ROLE and PROD_BOT_ROLE to constants.py (note: there is no generic bot role in the test discord, the role chosen was for MAB)

- Imported role along with the others in GeneralCommands.py (line 25)

- Add role to avoid_role (line 508)

- Updated text on lines 510 and 513