### PR TITLE
Various issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 2.3.0
 New commands:
-- [#577](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/577) `/rename_community_channel` - used in a Community Channel to rename both the channel and the role. Permissions: Community Mentor, Community Channel Owner
+- [#579](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/579) `/cco active` - toggles Active status for CCOs; CCOs set to active this way will not have the role removed for at least 28 days. Permissions: CCO, Fleet Reserve.
+- [#577](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/577) `/rename_community_channel` - used in a Community Channel to rename both the channel and the role. Permissions: Community Mentor, Community Channel Owner.
 - [#597](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/597) `Add Carrier` - Context Menu -> Message. Attempts to match PTN carrier name/ID format from a message and give the option of adding them to the database. Permissions: Council.
+- `/admin_opt_in` - List all CCO opt-ins. Permissions: Council.
 
 Other changes:
 - [#596](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/596) Fixed TimeoutError -> asyncio.TimeoutError
@@ -20,7 +22,7 @@ Other changes:
 - [#565](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/565) Update carrier channel mission embed creation to use guild user avatar rather than global
 - [#564](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/564) Archiving community channels now checks for successful permission sync and retries on failure
 - [#563](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/563) Fixed month not updating for image choice purposes
-- [#566](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/566) Fixed unloads showing carrier supply as if it was station demand
+- [#566](https://github.com/PilotsTradeNetwork/MissionAlertBot/ifssues/566) Fixed unloads showing carrier supply as if it was station demand
 - [#561](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/561) `m.complete` now includes an interactable link for `/mission complete`
 - [#560](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/560) Verify Member now includes a jumpurl in the bot-spam notification
 - [#569](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/569) Handle errors caused by users blocking DMs for all role-grant commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## 2.2.8
+## 2.3.0
+New commands:
+- [#577](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/577) `/rename_community_channel` - used in a Community Channel to rename both the channel and the role. Permissions: Community Mentor, Community Channel Owner
+- [#597](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/597) `Add Carrier` - Context Menu -> Message. Attempts to match PTN carrier name/ID format from a message and give the option of adding them to the database. Permissions: Council.
+
+Other changes:
+- [#596](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/596) Fixed TimeoutError -> asyncio.TimeoutError
+- [#593](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/593) All Reddit interactions will now abandon and return appropriate errors after a certain amount of time
+- More errors moved to error handler; better handling of certain errors
+- [#588](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/588) Added cAPI information and ;stock inara command to local mission information embed, unless mission is flagged EDMC-OFF
 
 
 ## 2.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ New commands:
 - [#579](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/579) `/cco active` - toggles Active status for CCOs; CCOs set to active this way will not have the role removed for at least 28 days. Permissions: CCO, Fleet Reserve.
 - [#577](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/577) `/rename_community_channel` - used in a Community Channel to rename both the channel and the role. Permissions: Community Mentor, Community Channel Owner.
 - [#597](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/597) `Add Carrier` - Context Menu -> Message. Attempts to match PTN carrier name/ID format from a message and give the option of adding them to the database. Permissions: Council.
-- `/admin_opt_in` - List all CCO opt-ins. Permissions: Council.
+- `/admin_opt_in` - List all CCO opt-ins. (This is for database maintenance purposes.) Permissions: Council. 
 
 Other changes:
+- [#578](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/578) `/cco load` `/cco unload` `/cco image` `/cco complete` will now accept any of the following as carrier search terms: full name partial string (as per default behaviour prior to 2.3.0); shortname; carrier registration (e.g. K8Y-T2G); carrier database entry number (discoverable via `/find`)
 - [#596](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/596) Fixed TimeoutError -> asyncio.TimeoutError
 - [#593](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/593) All Reddit interactions will now abandon and return appropriate errors after a certain amount of time
 - More errors moved to error handler; better handling of certain errors

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.2.8'
+__version__ = '2.3.0'

--- a/ptn/missionalertbot/botcommands/CCOCommands.py
+++ b/ptn/missionalertbot/botcommands/CCOCommands.py
@@ -28,7 +28,7 @@ from ptn.missionalertbot.database.database import find_mission, find_webhook_fro
 from ptn.missionalertbot.modules.DateString import get_mission_delete_hammertime, get_inactive_hammertime
 from ptn.missionalertbot.modules.Embeds import role_granted_embed, confirm_remove_role_embed, role_already_embed, confirm_grant_role_embed
 from ptn.missionalertbot.modules.ErrorHandler import on_app_command_error, on_generic_error, GenericError, CustomError
-from ptn.missionalertbot.modules.helpers import convert_str_to_float_or_int, check_command_channel, check_roles, check_training_mode
+from ptn.missionalertbot.modules.helpers import convert_str_to_float_or_int, check_command_channel, check_roles, check_training_mode, flexible_carrier_search_term
 from ptn.missionalertbot.modules.ImageHandling import assign_carrier_image
 from ptn.missionalertbot.modules.MissionGenerator import confirm_send_mission_via_button
 from ptn.missionalertbot.modules.MissionCleaner import _cleanup_completed_mission
@@ -156,7 +156,7 @@ async def cco_mission_complete(interaction, carrier, is_complete, message):
         f'{current_channel}')
 
     # resolve the carrier from the carriers db
-    carrier_data = find_carrier(carrier, CarrierDbFields.longname.name)
+    carrier_data = carrier_data = flexible_carrier_search_term(carrier)
     if not carrier_data:  # error condition
         try:
             error = f"No carrier found for '**{carrier}**.'"

--- a/ptn/missionalertbot/botcommands/CCOCommands.py
+++ b/ptn/missionalertbot/botcommands/CCOCommands.py
@@ -15,16 +15,17 @@ from discord.ext.commands import GroupCog
 
 # import local constants
 import ptn.missionalertbot.constants as constants
-from ptn.missionalertbot.constants import bot, mission_command_channel, certcarrier_role, trainee_role, seconds_long, rescarrier_role, commodities_common, bot_spam_channel, \
-    training_mission_command_channel, seconds_very_short, admin_role, mod_role, cco_mentor_role, aco_role, recruit_role
+from ptn.missionalertbot.constants import bot, mission_command_channel, certcarrier_role, trainee_role, seconds_long, rescarrier_role, commodities_common, \
+    bot_spam_channel, training_mission_command_channel, seconds_very_short, admin_role, mod_role, cco_mentor_role, aco_role, recruit_role
 
 # import local classes
 from ptn.missionalertbot.classes.MissionParams import MissionParams
 from ptn.missionalertbot.classes.Views import ConfirmRemoveRoleView, ConfirmGrantRoleView
 
 # import local modules
-from ptn.missionalertbot.database.database import find_mission, find_webhook_from_owner, add_webhook_to_database, find_webhook_by_name, delete_webhook_by_name, CarrierDbFields, find_carrier
-from ptn.missionalertbot.modules.DateString import get_mission_delete_hammertime
+from ptn.missionalertbot.database.database import find_mission, find_webhook_from_owner, add_webhook_to_database, find_webhook_by_name, delete_webhook_by_name, \
+    CarrierDbFields, find_carrier, _update_carrier_last_trade, add_carrier_to_database
+from ptn.missionalertbot.modules.DateString import get_mission_delete_hammertime, get_inactive_hammertime
 from ptn.missionalertbot.modules.Embeds import role_granted_embed, confirm_remove_role_embed, role_already_embed, confirm_grant_role_embed
 from ptn.missionalertbot.modules.ErrorHandler import on_app_command_error, on_generic_error, GenericError, CustomError
 from ptn.missionalertbot.modules.helpers import convert_str_to_float_or_int, check_command_channel, check_roles, check_training_mode
@@ -474,7 +475,7 @@ class CCOCommands(commands.Cog):
     @check_roles([certcarrier_role(), trainee_role(), rescarrier_role()])
     @check_command_channel([mission_command_channel(), training_mission_command_channel()])
     async def image(self, interaction: discord.Interaction, carrier: str):
-        print(f"{interaction.user.display_name} called m.carrier_image for {carrier}")
+        print(f"{interaction.user.display_name} called /cco image for {carrier}")
 
 
         embed = discord.Embed(
@@ -489,6 +490,68 @@ class CCOCommands(commands.Cog):
         await assign_carrier_image(interaction, carrier, embeds)
 
         return
+
+
+    # set active status
+    @cco_group.command(name='active', description='Set active status and receive the CCO role for at least 28 days.')
+    @check_roles([certcarrier_role(), rescarrier_role()])
+    async def cco_active(self, interaction: discord.Interaction):
+        print(f"{interaction.user} called /cco active")
+
+        try:
+
+            embed = discord.Embed(
+                description="⏳ Please wait a moment...",
+                color=constants.EMBED_COLOUR_QU
+            )
+
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+
+            # check if they have the CCO role
+            print("⏳ Checking for CCO role...")
+            cco_role = discord.utils.get(interaction.guild.roles, id=certcarrier_role())
+            if cco_role in interaction.user.roles:
+                print("▶ CCO role found. Transitioning user to inactive status.")
+                # check they have the Fleet Reserve role
+                reserve_role = discord.utils.get(interaction.guild.roles, id=rescarrier_role())
+                if reserve_role not in interaction.user.roles:
+                    print("⏳ No reserve role found. Adding...")
+                    # grant the reserve role
+                    await interaction.user.add_roles(reserve_role)
+                # remove the CCO role
+                print("▶ Removing CCO role")
+                await interaction.user.remove_roles(cco_role)
+                embed.description = f'💤 **Removed your <@&{cco_role.id}>** role. You are now marked inactive in the <@&{reserve_role.id}>.'
+                embed.set_footer(text='You can return to active status at any time by using this command again.')
+                embed.color = constants.EMBED_COLOUR_OK
+
+            else:
+                print("▶ No CCO role found. Transitioning user to active status.")
+                await interaction.user.add_roles(cco_role)
+                print("✅ Granted CCO role.")
+
+                # check if user has an opt-in entry yet
+                carrier_data = find_carrier(interaction.user.id, CarrierDbFields.shortname.name)
+                if carrier_data:
+                    print(f"Found opt-in database entry for {interaction.user}, updating lasttrade...")
+                    await _update_carrier_last_trade(carrier_data.pid)
+                else:
+                    print("No opt-in entry found, creating now.")
+                    await add_carrier_to_database(interaction.user.id, interaction.user.name, constants.OPT_IN_ID, interaction.user.name + '-opt-in-marker', 0, interaction.user.id)
+
+                embed.description = f'⚡ **Gave you the <@&{cco_role.id}>** role. You will remain active until at least {get_inactive_hammertime()}. If you run any trade missions with' \
+                            f' <@{bot.user.id}> during this period, your 28-day timer will reset from the time of each trade mission. '
+                embed.set_footer(text='You can return to inactive status at any time by using this command again.')
+                embed.color = constants.EMBED_COLOUR_OK
+
+            await interaction.edit_original_response(embed=embed)
+
+        except Exception as e:
+            try:
+                raise GenericError(e)
+            except Exception as e:
+                await on_generic_error(interaction, e)
+
 
     """
     Webhook management

--- a/ptn/missionalertbot/botcommands/CTeamCommands.py
+++ b/ptn/missionalertbot/botcommands/CTeamCommands.py
@@ -502,18 +502,7 @@ class CTeamCommands(commands.Cog):
     async def _rename_community_channel(self, interaction:  discord.Interaction, new_name: str, new_emoji: str = None):
         print(f"{interaction.user.name} used /rename_community_channel in {interaction.channel.name}")
 
-        message = None
-        print("Assigned message as None")
-
-        try:
-            print("Fetching non-existant message...")
-            message = await interaction.original_response()
-        except Exception as e:
-            print(f"Couldn't assign message: {e}")
-            await interaction.response.send_message("Hello")
-        print(message)
-        await interaction.response.send_message("Hello")
-        return
+        # TODO respond
 
         old_channel_name = interaction.channel.name
 

--- a/ptn/missionalertbot/botcommands/CTeamCommands.py
+++ b/ptn/missionalertbot/botcommands/CTeamCommands.py
@@ -5,18 +5,16 @@ Cog for Community Team commands
 
 # import libaries
 import os
-import emoji
 
 # import discord.py
 import discord
 from discord import Forbidden
 from discord import app_commands
 from discord.ext import commands
-from discord.ui import View, Button
 
 # import local classes
 from ptn.missionalertbot.classes.CommunityCarrierData import CommunityCarrierData
-from ptn.missionalertbot.classes.Views import RemoveCCView, SendNoticeModal, ConfirmRemoveRoleView
+from ptn.missionalertbot.classes.Views import RemoveCCView, SendNoticeModal, ConfirmRemoveRoleView, ConfirmRenameCC
 
 # import local constants
 import ptn.missionalertbot.constants as constants
@@ -28,7 +26,7 @@ from ptn.missionalertbot.database.database import carrier_db
 from ptn.missionalertbot.modules.ErrorHandler import on_app_command_error, GenericError, on_generic_error
 from ptn.missionalertbot.modules.helpers import check_roles, _regex_alphanumeric_with_hyphens, _cc_owner_check, _cc_role_create_check, \
     _cc_create_channel, _cc_role_create, _cc_assign_permissions, _cc_db_enter, _remove_cc_role_from_owner, _cc_role_delete, _openclose_community_channel, \
-    _send_notice_channel_check, check_command_channel
+    _community_channel_owner_check, check_command_channel, _cc_name_string_check
 from ptn.missionalertbot.modules.Embeds import _generate_cc_notice_embed, verified_member_embed, event_organiser_embed, role_granted_embed, role_already_embed, \
     confirm_remove_role_embed, dm_forbidden_embed
 
@@ -165,7 +163,7 @@ async def toggle_event_organiser(interaction:  discord.Interaction, member: disc
 async def send_cc_notice(interaction:  discord.Interaction, message: discord.Message):
     print(f"{interaction.user.name} used send context menu in {interaction.channel.name}")
 
-    community_carrier = await _send_notice_channel_check(interaction)
+    community_carrier = await _community_channel_owner_check(interaction)
     if not community_carrier: return
 
     try:
@@ -197,7 +195,7 @@ async def edit_cc_notice(interaction:  discord.Interaction, message: discord.Mes
     print(f"{interaction.user.name} used edit CC notice context menu in {interaction.channel.name}")
 
     # check we're in a CC channel and get the CC data
-    community_carrier = await _send_notice_channel_check(interaction)
+    community_carrier = await _community_channel_owner_check(interaction)
     if not community_carrier: return
 
     """
@@ -227,7 +225,7 @@ async def edit_cc_notice(interaction:  discord.Interaction, message: discord.Mes
 @check_roles([cmentor_role(), admin_role(), cc_role()])
 async def upload_cc_thumb(interaction:  discord.Interaction, message: discord.Message):
     # check we're in the CC channel
-    if not await _send_notice_channel_check(interaction): return
+    if not await _community_channel_owner_check(interaction): return
 
     if message.attachments:
         for attachment in message.attachments: # there can only be one attachment per message
@@ -254,6 +252,7 @@ COMMUNITY TEAM COMMANDS
 /community_channel_help - community
 /create_community_channel - community
 /open_community_channel -community
+/rename_community_channel - community
 /remove_community_channel - community
 /restore_community_channel - community
 /send_notice - community
@@ -296,30 +295,8 @@ class CTeamCommands(commands.Cog):
     async def _create_community_channel(self, interaction:  discord.Interaction, owner: discord.Member, channel_name: str, channel_emoji: str = None):
         print(f"{interaction.user.name} used /create_community_channel")
         print(f"Params: {owner} {channel_name} {channel_emoji}")
-        # trim emojis to 1 character
-        emoji_string = channel_emoji[:1] if not channel_emoji == None else None
 
-        # PROCESS: check for valid emoji
-        print(emoji.is_emoji(emoji_string))
-        if not emoji.is_emoji(emoji_string) and not emoji_string == None:
-            embed = discord.Embed(description="❌ Invalid emoji supplied. Use a valid Unicode emoji from your emoji keyboard,"
-                                            f"or leave the field blank. **Discord custom emojis will not work**.", color=constants.EMBED_COLOUR_ERROR)
-            bu_link = Button(label="Full Emoji List", url="https://unicode.org/emoji/charts/full-emoji-list.html")
-            view = View()
-            view.add_item(bu_link)
-            return await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
-
-        # PROCESS: remove unusable characters and render to lowercase
-        stripped_channel_name = _regex_alphanumeric_with_hyphens(channel_name.lower())
-
-        # check the channel name isn't too long
-        if len(stripped_channel_name) > 30:
-            embed = discord.Embed(description="❌ Channel name should be fewer than 30 characters. (Preferably a *lot* fewer.)", color=constants.EMBED_COLOUR_ERROR)
-            return await interaction.response.send_message(embed=embed, ephemeral=True)
-
-        # join with the emoji
-        new_channel_name = emoji_string + stripped_channel_name if not emoji_string == None else stripped_channel_name
-        print(f"Candidate channel name: {new_channel_name}")
+        new_channel_name = await _cc_name_string_check(interaction, channel_emoji, channel_name)
 
         # CHECK: user already owns a channel
         if not await _cc_owner_check(interaction, owner): return
@@ -339,21 +316,20 @@ class CTeamCommands(commands.Cog):
             if new_channel.category == cc_category:
                 embed = discord.Embed(description=f"❌ A Community channel <#{new_channel.id}> already exists."
                                     f" Please choose a different name for your Community channel.", color=constants.EMBED_COLOUR_ERROR)
-                await interaction.response.send_message(embed=embed)
+                return await interaction.response.send_message(embed=embed)
 
             # check whether it's an archived CC channel
             elif new_channel.category == archive_category:
                 embed = discord.Embed(description=f"❌ A Community channel <#{new_channel.id}> already exists in the archives."
                                     f" Use `/restore_community_channel` in the channel to restore it.", color=constants.EMBED_COLOUR_ERROR)
-                await interaction.response.send_message(embed=embed)
+                return await interaction.response.send_message(embed=embed)
 
             # the channel must exist with that name elsewhere on the server and so can't be used
             else:
                 embed = discord.Embed(description=f"❌ A channel <#{new_channel.id}> already exists on the server"
                                     f" and does not appear to be a Community channel."
                                     f" Please choose a different name for your Community channel.", color=constants.EMBED_COLOUR_ERROR)
-                await interaction.response.send_message(embed=embed)
-                return
+                return await interaction.response.send_message(embed=embed)
 
         else:
             # channel does not exist, create it
@@ -517,6 +493,47 @@ class CTeamCommands(commands.Cog):
         await _openclose_community_channel(interaction, open)
 
 
+    # rename a community channel and role
+    @app_commands.command(name="rename_community_channel",
+        description="Use in a Community Channel to change the name of its channel and associated role.", )
+    @app_commands.describe(new_name='The updated name for this community channel/role.',
+                           new_emoji='Optional: pick an emoji to go at the start of the channel/role name.')
+    @check_roles([cmentor_role(), admin_role(), cc_role()]) # allow owners to open/close their own channels
+    async def _rename_community_channel(self, interaction:  discord.Interaction, new_name: str, new_emoji: str = None):
+        print(f"{interaction.user.name} used /rename_community_channel in {interaction.channel.name}")
+
+        message = None
+        print("Assigned message as None")
+
+        try:
+            print("Fetching non-existant message...")
+            message = await interaction.original_response()
+        except Exception as e:
+            print(f"Couldn't assign message: {e}")
+            await interaction.response.send_message("Hello")
+        print(message)
+        await interaction.response.send_message("Hello")
+        return
+
+        old_channel_name = interaction.channel.name
+
+        embed = discord.Embed(
+            description="⏳ Please wait a moment...",
+            color=constants.EMBED_COLOUR_QU
+        )
+        await interaction.response.send_message(embed=embed, view=None) # tell the user we're working on it
+
+        # check the user has authority to do this
+        community_carrier = await _community_channel_owner_check(interaction)
+        if not community_carrier: return
+
+        # process the new channel/role name
+        new_channel_name = await _cc_name_string_check(interaction, new_emoji, new_name)
+
+        # confirm user choice
+        view = ConfirmRenameCC(community_carrier, old_channel_name, new_channel_name)
+
+
     # send a notice from a Community Carrier owner to their 'crew' - this is the long form command using a modal
     @app_commands.command(name="send_notice",
         description="Private command: Used by Community Channel owners to send notices to their participants.", )
@@ -524,7 +541,8 @@ class CTeamCommands(commands.Cog):
     async def _send_notice(self, interaction:  discord.Interaction):
         print(f"{interaction.user.name} used /send_notice in {interaction.channel.name}")
 
-        community_carrier = await _send_notice_channel_check(interaction)
+        # check the user has authority to do this
+        community_carrier = await _community_channel_owner_check(interaction)
         if not community_carrier: return
 
         # create a modal to take the message

--- a/ptn/missionalertbot/botcommands/CTeamCommands.py
+++ b/ptn/missionalertbot/botcommands/CTeamCommands.py
@@ -502,8 +502,6 @@ class CTeamCommands(commands.Cog):
     async def _rename_community_channel(self, interaction:  discord.Interaction, new_name: str, new_emoji: str = None):
         print(f"{interaction.user.name} used /rename_community_channel in {interaction.channel.name}")
 
-        # TODO respond
-
         old_channel_name = interaction.channel.name
 
         embed = discord.Embed(

--- a/ptn/missionalertbot/botcommands/CTeamCommands.py
+++ b/ptn/missionalertbot/botcommands/CTeamCommands.py
@@ -513,7 +513,9 @@ class CTeamCommands(commands.Cog):
 
             # check the user has authority to do this
             community_carrier = await _community_channel_owner_check(interaction)
-            if not community_carrier: return
+            if not community_carrier:
+                await interaction.delete_original_response()
+                return
 
             # process the new channel/role name
             new_channel_name = await _cc_name_string_check(interaction, new_emoji, new_name)
@@ -522,6 +524,7 @@ class CTeamCommands(commands.Cog):
             existing_channel = discord.utils.get(interaction.guild.channels, name=new_channel_name)
             if existing_channel:
                 error=f'<#{existing_channel.id}> already exists. Please choose another.'
+                await interaction.delete_original_response()
                 try:
                     raise CustomError(error)
                 except Exception as e:
@@ -529,6 +532,7 @@ class CTeamCommands(commands.Cog):
             existing_role = discord.utils.get(interaction.guild.roles, name=new_channel_name)
             if existing_role:
                 error=f'<@&{existing_role.id}> already exists. Please choose another.'
+                await interaction.delete_original_response()
                 try:
                     raise CustomError(error)
                 except Exception as e:
@@ -546,6 +550,7 @@ class CTeamCommands(commands.Cog):
             view.message = await interaction.original_response()
 
         except Exception as e:
+            await interaction.delete_original_response()
             traceback.print_exc()
             try:
                 raise GenericError(e)

--- a/ptn/missionalertbot/botcommands/DatabaseInteraction.py
+++ b/ptn/missionalertbot/botcommands/DatabaseInteraction.py
@@ -24,7 +24,7 @@ from ptn.missionalertbot.classes.Views import db_delete_View, BroadcastView, Car
 # local constants
 import ptn.missionalertbot.constants as constants
 from ptn.missionalertbot.constants import bot, cmentor_role, admin_role, cteam_bot_channel, cteam_bot_channel, bot_command_channel, cc_role, \
-    admin_role, mod_role
+    admin_role, mod_role, bot_spam_channel, fc_complete_emoji
 
 # local modules
 from ptn.missionalertbot.database.database import find_nominee_with_id, carrier_db, CarrierDbFields, find_carrier, backup_database, \
@@ -67,11 +67,12 @@ async def add_carrier(interaction:  discord.Interaction, message: discord.Messag
         owner_id = details['owner_id']
         channel_name = details['channel_name']
         print(f"Index {index} is '{long_name}' ({carrier_id}) with generated shortname {short_name}")
-        embed.add_field(name=f'Match {index+1}', value=f'Longname: `{long_name}` Shortname: `{short_name}` ID: `{carrier_id}` Owner: <@{owner_id}> ChannelName: `{channel_name}`', inline=False)
+        embed.add_field(name=f'Match {index+1}', value=f'Longname: `{long_name}` • Shortname: `{short_name}` • ID: `{carrier_id}` • Owner: <@{owner_id}> • ChannelName: #`{channel_name}`', inline=False)
 
     # TODO check no two fields are identical
 
     embed.title="🔎 CARRIER DETAILS FOUND IN MESSAGE"
+    embed.description=None
 
     view = AddCarrierButtons(message, carrier_details)
 
@@ -339,7 +340,17 @@ class DatabaseInteraction(commands.Cog):
 
         embeds = [info_embed, cp_embed]
 
-        return await interaction.response.send_message(embeds=embeds)
+        await interaction.response.send_message(embeds=embeds)
+
+        # notify bot-spam
+        spamchannel: discord.TextChannel = bot.get_channel(bot_spam_channel())
+        message: discord.Message = await interaction.original_response()
+        embed = discord.Embed(
+            description=f"<:fc_complete:{fc_complete_emoji()}> **NEW FLEET CARRIER** added by <@{interaction.user.id}> at {message.jump_url}",
+            color=constants.EMBED_COLOUR_OK
+        )
+        embed = _add_common_embed_fields(embed, carrier_data, interaction)
+        return await spamchannel.send(embed=embed)
 
 
     # remove FC from database

--- a/ptn/missionalertbot/classes/Views.py
+++ b/ptn/missionalertbot/classes/Views.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 # import discord.py
 import discord
-from discord import HTTPException
+from discord import HTTPException, NotFound
 from discord.ui import View, Modal
 
 # import local constants
@@ -23,9 +23,11 @@ from ptn.missionalertbot.constants import seconds_long, o7_emoji, bot_spam_chann
 import ptn.missionalertbot.classes.CommunityCarrierData as CommunityCarrierData
 
 # import local modules
-from ptn.missionalertbot.database.database import delete_nominee_from_db, delete_carrier_from_db, _update_carrier_details_in_database, find_carrier, CarrierDbFields, mission_db, missions_conn
+from ptn.missionalertbot.database.database import delete_nominee_from_db, delete_carrier_from_db, _update_carrier_details_in_database, find_carrier, CarrierDbFields, \
+    mission_db, missions_conn, add_carrier_to_database
 from ptn.missionalertbot.modules.DateString import get_mission_delete_hammertime
-from ptn.missionalertbot.modules.Embeds import _configure_all_carrier_detail_embed, _generate_cc_notice_embed, role_removed_embed, role_granted_embed, cc_renamed_embed
+from ptn.missionalertbot.modules.Embeds import _configure_all_carrier_detail_embed, _generate_cc_notice_embed, role_removed_embed, role_granted_embed, cc_renamed_embed, \
+    _add_common_embed_fields
 from ptn.missionalertbot.modules.ErrorHandler import GenericError, on_generic_error, CustomError, AsyncioTimeoutError
 from ptn.missionalertbot.modules.helpers import _remove_cc_manager
 from ptn.missionalertbot.modules.MissionCleaner import _cleanup_completed_mission
@@ -746,3 +748,126 @@ class SendNoticeModal(Modal):
 
     async def on_error(self, interaction: discord.Interaction, error: Exception) -> None:
         await interaction.response.send_message(f'Oops! Something went wrong: {error}', ephemeral=True)
+
+
+# Buttons for Add Carrier interaction
+class AddCarrierButtons(View):
+    def __init__(self, message, carrier_details):
+        self.message: discord.Message = message
+        self.carrier_details: dict = carrier_details
+        super().__init__(timeout=60)
+
+    @discord.ui.button(label='✗ Cancel', style=discord.ButtonStyle.secondary, custom_id='add_carrier_cancel')
+    async def add_carrier_cancel_button(self, interaction: discord.Interaction, button):
+        embed = discord.Embed(
+            description="Cancelled.",
+            color=constants.EMBED_COLOUR_OK
+        )
+        await interaction.response.edit_message(embed=embed, view=None)
+        pass
+
+    @discord.ui.button(label='✔ Add All to DB', style=discord.ButtonStyle.primary, custom_id='add_carrier_add_all')
+    async def add_carrier_add_all(self, interaction: discord.Interaction, button):
+
+        embed = discord.Embed(
+            description="⏳ Please wait a moment...",
+            color=constants.EMBED_COLOUR_QU
+        )
+
+        await interaction.response.edit_message(embed=embed, view=None)
+
+        # define our function that will be used to check for duplicate entries
+        def check_for_duplicates(details):
+            try:
+                carrier_data = find_carrier(details['long_name'], CarrierDbFields.longname.name)
+                if carrier_data:
+                    print(f"Duplicate long_name: {carrier_data}")
+                    duplicate = details['long_name']
+                    return duplicate, carrier_data
+                carrier_data = find_carrier(details['carrier_id'], CarrierDbFields.cid.name)
+                if carrier_data:
+                    print(f"Duplicate carrier_id: {carrier_data}")
+                    duplicate = details['carrier_id']
+                    return duplicate, carrier_data
+                carrier_data = find_carrier(details['short_name'], CarrierDbFields.shortname.name)
+                if carrier_data:
+                    print(f"Duplicate short_name: {carrier_data}")
+                    duplicate = details['short_name']
+                    return duplicate, carrier_data
+                else:
+                    duplicate = None
+            except Exception as e:
+                print(e)
+            return duplicate, None
+
+
+        for details in self.carrier_details:
+            long_name = details['long_name']
+            carrier_id = details['carrier_id']
+            short_name = details['short_name']
+            owner_id = details['owner_id']
+            channel_name = details['channel_name']
+            try:
+                # call our duplicates check
+                print("Checking for existing data in DB")
+                duplicate, carrier_data = check_for_duplicates(details)
+                if duplicate:
+                    # skip the carrier and notify the user
+                    print(f'Request recieved from {interaction.user} to add a carrier that already exists in the database ({long_name}).')
+
+                    embed = discord.Embed(
+                        title="Fleet carrier already exists, use /carrier_edit to change its details.",
+                        description=f"Carrier data matched for {duplicate}",
+                        color=constants.EMBED_COLOUR_OK
+                    )
+                    embed = _add_common_embed_fields(embed, carrier_data, interaction)
+
+                    await interaction.followup.send(embed=embed)
+
+                else:
+                    # continue with adding carrier
+                    await add_carrier_to_database(short_name.lower(), long_name.upper(), carrier_id.upper(), channel_name.lower(), 0, owner_id)
+                    carrier_data = find_carrier(long_name, CarrierDbFields.longname.name)
+                    info_embed = discord.Embed(title="Fleet Carrier successfully added to database",
+                                        color=constants.EMBED_COLOUR_OK)
+                    info_embed = _add_common_embed_fields(info_embed, carrier_data, interaction)
+
+                    cp_embed = discord.Embed(
+                        title="Copy/Paste code for Stockbot",
+                        description=f"```;add_FC {carrier_data.carrier_identifier} {carrier_data.carrier_short_name} {carrier_data.ownerid}```",
+                        color=constants.EMBED_COLOUR_QU
+                    )
+
+                    embeds = [info_embed, cp_embed]
+
+                    # TODO link with existing add_carrier function to remove duplicate code
+
+                    await interaction.followup.send(embeds=embeds)
+
+            except Exception as e:
+                error = f"Failed adding {details['ptn_string']}. Please add it manually. Error: {e}"
+                try:
+                    raise CustomError(error)
+                except Exception as e:
+                    await on_generic_error(interaction, e)
+        
+        await interaction.delete_original_response()
+
+
+    async def on_timeout(self): 
+        # remove buttons
+        self.clear_items()
+        print("View timed out")
+
+        # return a message to the user that the interaction has timed out
+        timeout_embed = discord.Embed(
+            description="⏲ Timed out.",
+            color=constants.EMBED_COLOUR_ERROR
+        )
+
+        try:
+            await self.message.edit(embed=timeout_embed, view=self)
+        except NotFound: # we don't care about 404 as we're deleting the original message
+            pass
+        except Exception as e:
+            print(f'Failed applying timeout: {e}')

--- a/ptn/missionalertbot/classes/Views.py
+++ b/ptn/missionalertbot/classes/Views.py
@@ -17,7 +17,7 @@ from discord.ui import View, Modal
 
 # import local constants
 import ptn.missionalertbot.constants as constants
-from ptn.missionalertbot.constants import seconds_long, o7_emoji, bot_spam_channel, bot
+from ptn.missionalertbot.constants import seconds_long, o7_emoji, bot_spam_channel, bot, fc_complete_emoji, bot_command_channel
 
 # import local classes
 import ptn.missionalertbot.classes.CommunityCarrierData as CommunityCarrierData
@@ -834,7 +834,7 @@ class AddCarrierButtons(View):
 
                     cp_embed = discord.Embed(
                         title="Copy/Paste code for Stockbot",
-                        description=f"```;add_FC {carrier_data.carrier_identifier} {carrier_data.carrier_short_name} {carrier_data.ownerid}```",
+                        description=f"▶ <#{bot_command_channel()}>:\n```;add_FC {carrier_data.carrier_identifier} {carrier_data.carrier_short_name} {carrier_data.ownerid}```",
                         color=constants.EMBED_COLOUR_QU
                     )
 
@@ -843,6 +843,17 @@ class AddCarrierButtons(View):
                     # TODO link with existing add_carrier function to remove duplicate code
 
                     await interaction.followup.send(embeds=embeds)
+
+                    # notify bot-spam
+                    print("Notify bot-spam")
+                    spamchannel: discord.TextChannel = bot.get_channel(bot_spam_channel())
+                    print(spamchannel)
+                    embed = discord.Embed(
+                        description=f"<:fc_complete:{fc_complete_emoji()}> **NEW FLEET CARRIER** added by <@{interaction.user.id}> from {self.message.jump_url}",
+                        color=constants.EMBED_COLOUR_OK
+                    )
+                    embed = _add_common_embed_fields(embed, carrier_data, interaction)
+                    await spamchannel.send(embed=embed)
 
             except Exception as e:
                 error = f"Failed adding {details['ptn_string']}. Please add it manually. Error: {e}"

--- a/ptn/missionalertbot/classes/Views.py
+++ b/ptn/missionalertbot/classes/Views.py
@@ -138,22 +138,21 @@ class ConfirmRemoveRoleView(View):
         )
         return await interaction.response.edit_message(embed=self.embed, view=None)
 
-    async def on_timeout(self):
+    async def on_timeout(self): 
         # remove buttons
         self.clear_items()
+        print("View timed out")
 
-        if not self.embed:
         # return a message to the user that the interaction has timed out
-            timeout_embed = discord.Embed(
-                description="Timed out.",
-                color=constants.EMBED_COLOUR_ERROR
-            )
-            self.embed = timeout_embed
+        timeout_embed = discord.Embed(
+            description="Timed out.",
+            color=constants.EMBED_COLOUR_ERROR
+        )
 
         try:
-            await self.message.edit(embed=self.embed, view=self)
+            await self.message.edit(embed=timeout_embed, view=self)
         except Exception as e:
-            print(e)
+            print(f'Failed applying timeout: {e}')
 
 
 # buttons for community channel rename
@@ -183,11 +182,13 @@ class ConfirmRenameCC(View):
             # rename channel
             action = 'channel'
             await interaction.channel.edit(name=self.new_channel_name)
+            print("Renamed channel")
 
             # rename role
             action = 'role'
             role = discord.utils.get(interaction.guild.roles, id=self.community_carrier.role_id)
             await role.edit(name=self.new_channel_name)
+            print("Renamed role")
 
         except Exception as e:
             error = f'Failed to rename {action}: {e}'
@@ -208,23 +209,21 @@ class ConfirmRenameCC(View):
             except Exception as e:
                 await on_generic_error(interaction, e)
 
-
-    async def on_timeout(self):
+    async def on_timeout(self): 
         # remove buttons
         self.clear_items()
+        print("View timed out")
 
-        if not self.embed:
         # return a message to the user that the interaction has timed out
-            timeout_embed = discord.Embed(
-                description="Timed out.",
-                color=constants.EMBED_COLOUR_ERROR
-            )
-            self.embed = timeout_embed
+        timeout_embed = discord.Embed(
+            description="Timed out.",
+            color=constants.EMBED_COLOUR_ERROR
+        )
 
         try:
-            await self.message.edit(embed=self.embed, view=self)
+            await self.message.edit(embed=timeout_embed, view=self)
         except Exception as e:
-            print(e)
+            print(f'Failed applying timeout: {e}')
 
 # buttons for mission manual delete
 class MissionDeleteView(View):

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -79,6 +79,7 @@ PROD_ROLEAPPS_CHANNEL = 867820665515147293 # role-applications on the live serve
 PROD_UPVOTE_EMOJI = 828287733227192403 # upvote emoji on live server
 PROD_O7_EMOJI = 806138784294371368 # o7 emoji on live server
 PROD_FC_COMPLETE_EMOJI = 878216234653605968 # fc_complete emoji
+PROD_FC_EMPTY_EMOJI = 878216288525242388 # fc_empty emoji
 PROD_DISCORD_EMOJI = 1122605426844905503 # Discord emoji on live
 PROD_HAULER_ROLE = 875313960834965544 # hauler role ID on live server
 PROD_WINELOADER_ROLE = 881809680765165578 # wine loader role on live
@@ -135,6 +136,7 @@ TEST_ROLEAPPS_CHANNEL = 1121736676247609394 # role-applications on the test serv
 TEST_UPVOTE_EMOJI = 849388681382068225 # upvote emoji on test server
 TEST_O7_EMOJI = 903744117144698950 # o7 emoji on test server
 TEST_FC_COMPLETE_EMOJI = 884673510067286076 # fc_complete emoji
+TEST_FC_EMPTY_EMOJI = 974747678183424050 # fc_empty emoji
 TEST_DISCORD_EMOJI = 1122605718198026300 # Discord emoji on live
 TEST_HAULER_ROLE = 875439909102575647 # hauler role ID on test server
 TEST_WINELOADER_ROLE = 1119189364522623068 # wine loader role on test
@@ -364,6 +366,9 @@ def o7_emoji():
 
 def fc_complete_emoji():
   return PROD_FC_COMPLETE_EMOJI if _production else TEST_FC_COMPLETE_EMOJI
+
+def fc_empty_emoji():
+  return PROD_FC_EMPTY_EMOJI if _production else TEST_FC_EMPTY_EMOJI
 
 def discord_emoji():
   return PROD_DISCORD_EMOJI if _production else TEST_DISCORD_EMOJI

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -284,6 +284,8 @@ def mission_template_filename(current_month):
 
 DISCORD_TEMPLATE = 'discord_template.png'
 
+OPT_IN_ID = 'OPT-INX'
+
 # images and icons used in mission embeds
 BLANKLINE_400PX = 'https://pilotstradenetwork.com/wp-content/uploads/2023/01/400x1-00000000.png'
 ICON_BUY = 'https://pilotstradenetwork.com/wp-content/uploads/2023/05/Trade.png'

--- a/ptn/missionalertbot/database/database.py
+++ b/ptn/missionalertbot/database/database.py
@@ -427,8 +427,9 @@ async def add_carrier_to_database(short_name, long_name, carrier_id, channel, ch
     await carrier_db_lock.acquire()
     try:
         carrier_db.execute(''' INSERT INTO carriers VALUES(NULL, ?, ?, ?, ?, ?, ?, strftime('%s','now')) ''',
-                           (short_name.lower(), long_name.upper(), carrier_id.upper(), channel, channel_id, owner_id))
+                           (short_name, long_name, carrier_id, channel, channel_id, owner_id))
         carriers_conn.commit()
+        print(f'Added {long_name} to database')
     finally:
         carrier_db_lock.release()
 
@@ -481,6 +482,19 @@ async def _update_carrier_details_in_database(carrier_data, original_name):
             WHERE longname LIKE (?) ''', data
         )
 
+        carriers_conn.commit()
+    finally:
+        carrier_db_lock.release()
+
+
+# update carrier last trade time
+async def _update_carrier_last_trade(pid):
+    await carrier_db_lock.acquire()
+    try:
+        carrier_db.execute(
+            ''' UPDATE carriers
+            SET lasttrade=strftime('%s','now')
+            WHERE p_ID=? ''', ( [ pid ] ))
         carriers_conn.commit()
     finally:
         carrier_db_lock.release()
@@ -603,6 +617,22 @@ def find_carriers_mult(searchterm, searchfield):
         print(f"FC {carrier.pid} is {carrier.carrier_long_name} {carrier.carrier_identifier} called by "
               f"shortname {carrier.carrier_short_name} with channel <#{carrier.channel_id}> "
               f"and owner {carrier.ownerid} called from find_carriers_mult.")
+
+    return carrier_data
+
+
+def find_opt_ins():
+    """
+    Returns all carriers matching the opt-in marker designation.
+    """
+    carrier_db.execute(
+        f"SELECT * FROM carriers WHERE cid LIKE (?)", (f'%{constants.OPT_IN_ID}%',)
+    )
+    carrier_data = [CarrierData(carrier) for carrier in carrier_db.fetchall()]
+    for carrier in carrier_data:
+        print(f"FC {carrier.pid} is {carrier.carrier_long_name} {carrier.carrier_identifier} called by "
+              f"shortname {carrier.carrier_short_name} with channel <#{carrier.channel_id}> "
+              f"and owner {carrier.ownerid} called from find_opt_ins.")
 
     return carrier_data
 

--- a/ptn/missionalertbot/database/database.py
+++ b/ptn/missionalertbot/database/database.py
@@ -596,7 +596,7 @@ def find_carriers_mult(searchterm, searchfield):
     :rtype: list[CarrierData]
     """
     carrier_db.execute(
-        f"SELECT * FROM carriers WHERE {searchfield} LIKE (?)", (f'%{searchterm}%',)
+        f"SELECT * FROM carriers WHERE {searchfield} LIKE (?) AND shortname != ownerid", (f'%{searchterm}%',)
     )
     carrier_data = [CarrierData(carrier) for carrier in carrier_db.fetchall()]
     for carrier in carrier_data:

--- a/ptn/missionalertbot/modules/DateString.py
+++ b/ptn/missionalertbot/modules/DateString.py
@@ -45,3 +45,10 @@ def get_final_delete_hammertime():
     posix_time_string = posix_time_string + seconds_very_short()
     hammertime = f"<t:{posix_time_string}:R>"
     return hammertime
+
+def get_inactive_hammertime():
+    posix_time_string = get_formatted_date_string()[2]
+    days = 28*24*60*60
+    posix_time_string = posix_time_string + days
+    hammertime = f"<t:{posix_time_string}:F>"
+    return hammertime

--- a/ptn/missionalertbot/modules/Embeds.py
+++ b/ptn/missionalertbot/modules/Embeds.py
@@ -13,7 +13,8 @@ from time import strftime
 import discord
 
 # import local classes
-import ptn.missionalertbot.classes.CarrierData as CarrierData
+from ptn.missionalertbot.classes.CarrierData import CarrierData
+from ptn.missionalertbot.classes.CommunityCarrierData import CommunityCarrierData
 
 # import local constants
 import ptn.missionalertbot.constants as constants
@@ -238,7 +239,7 @@ def confirm_grant_role_embed(user, role):
     return embed
 
 # embed to feedback that a user had a role removed
-def role_removed_embed(interaction, user, role):
+def role_removed_embed(interaction: discord.Interaction, user, role):
     print("Called role_removed_embed")
     desc = f"""
     ✅ Removed the <@&{role.id}> role from <@{user.id}>.
@@ -256,6 +257,34 @@ def role_removed_embed(interaction, user, role):
         command_name = ""
 
     desc = f"<@{interaction.user.id}> removed the <@&{role.id}> role from <@{user.id}>" + command_name
+
+    bot_spam_embed = discord.Embed (
+        description=desc,
+        color=constants.EMBED_COLOUR_OK
+    )
+
+    print("Returning embed")
+    return embed, bot_spam_embed
+
+# embeds to feed back CC channel rename
+def cc_renamed_embed(interaction, old_channel_name, community_carrier: CommunityCarrierData):
+    print("Called cc_renamed_embed")
+    desc = f"""
+    ✅ Updated names: <#{community_carrier.channel_id}> • <@&{community_carrier.role_id}>.
+    """
+    embed = discord.Embed (
+        description=desc,
+        color=constants.EMBED_COLOUR_OK
+    )
+
+    try:
+        print("Checking for command name...")
+        command_name = f" using `{interaction.command.name}`"
+    except:
+        print("Command name not accessible")
+        command_name = ""
+
+    desc = f"<@{interaction.user.id}> renamed <#{community_carrier.channel_id}> • <@&{community_carrier.role_id}> (was `{old_channel_name}`)" + command_name
 
     bot_spam_embed = discord.Embed (
         description=desc,

--- a/ptn/missionalertbot/modules/ImageHandling.py
+++ b/ptn/missionalertbot/modules/ImageHandling.py
@@ -23,6 +23,7 @@ from ptn.missionalertbot.constants import bot, REG_FONT, NAME_FONT, TITLE_FONT, 
 # import local modules
 from ptn.missionalertbot.modules.DateString import get_formatted_date_string
 from ptn.missionalertbot.database.database import find_carrier, CarrierDbFields
+from ptn.missionalertbot.modules.helpers import flexible_carrier_search_term
 
 
 # function to overlay carrier image with background template for Reddit
@@ -139,7 +140,8 @@ def cleanup_temp_image_file(file_name):
 # function to assign or change a carrier image file
 async def assign_carrier_image(interaction: discord.Interaction, lookname, original_embeds):
     print('assign_carrier_image called')
-    carrier_data = find_carrier(lookname, CarrierDbFields.longname.name)
+
+    carrier_data = flexible_carrier_search_term(lookname)
 
     # check carrier exists
     if not carrier_data:

--- a/ptn/missionalertbot/modules/MissionGenerator.py
+++ b/ptn/missionalertbot/modules/MissionGenerator.py
@@ -39,7 +39,7 @@ from ptn.missionalertbot.constants import bot, get_reddit, seconds_short, upvote
 
 # import local modules
 from ptn.missionalertbot.database.database import backup_database, mission_db, missions_conn, find_carrier, CarrierDbFields, \
-    find_commodity, find_mission, carrier_db, carriers_conn, find_webhook_from_owner
+    find_commodity, find_mission, carrier_db, carriers_conn, find_webhook_from_owner, _update_carrier_last_trade
 from ptn.missionalertbot.modules.DateString import get_formatted_date_string
 from ptn.missionalertbot.modules.Embeds import _mission_summary_embed
 from ptn.missionalertbot.modules.ErrorHandler import on_generic_error, CustomError, AsyncioTimeoutError
@@ -1419,8 +1419,7 @@ async def mission_add(mission_params):
     print("Mission added to db")
 
     print("Updating last trade timestamp for carrier")
-    carrier_db.execute(''' UPDATE carriers SET lasttrade=strftime('%s','now') WHERE p_ID=? ''', ( [ mission_params.carrier_data.pid ] ))
-    carriers_conn.commit()
+    await _update_carrier_last_trade(mission_params.carrier_data.pid)
 
     spamchannel = bot.get_channel(bot_spam_channel())
 

--- a/ptn/missionalertbot/modules/MissionGenerator.py
+++ b/ptn/missionalertbot/modules/MissionGenerator.py
@@ -33,9 +33,8 @@ from ptn.missionalertbot.classes.MissionParams import MissionParams
 
 # import local constants
 import ptn.missionalertbot.constants as constants
-from ptn.missionalertbot.constants import bot, get_reddit, seconds_short, upvote_emoji, hauler_role, trainee_role, \
-    get_guild, get_overwrite_perms, ptn_logo_discord, wineloader_role, o7_emoji, bot_spam_channel, discord_emoji, training_cat, trade_cat, \
-    reddit_timeout
+from ptn.missionalertbot.constants import bot, get_reddit, seconds_short, upvote_emoji, hauler_role, trainee_role, reddit_timeout, \
+    get_guild, get_overwrite_perms, ptn_logo_discord, wineloader_role, o7_emoji, bot_spam_channel, discord_emoji, training_cat, trade_cat
 
 # import local modules
 from ptn.missionalertbot.database.database import backup_database, mission_db, missions_conn, find_carrier, CarrierDbFields, \
@@ -43,7 +42,7 @@ from ptn.missionalertbot.database.database import backup_database, mission_db, m
 from ptn.missionalertbot.modules.DateString import get_formatted_date_string
 from ptn.missionalertbot.modules.Embeds import _mission_summary_embed
 from ptn.missionalertbot.modules.ErrorHandler import on_generic_error, CustomError, AsyncioTimeoutError
-from ptn.missionalertbot.modules.helpers import lock_mission_channel, unlock_mission_channel, check_mission_channel_lock
+from ptn.missionalertbot.modules.helpers import lock_mission_channel, unlock_mission_channel, check_mission_channel_lock, flexible_carrier_search_term
 from ptn.missionalertbot.modules.ImageHandling import assign_carrier_image, create_carrier_reddit_mission_image, create_carrier_discord_mission_image
 from ptn.missionalertbot.modules.MissionCleaner import remove_carrier_channel
 from ptn.missionalertbot.modules.TextGen import txt_create_discord, txt_create_reddit_body, txt_create_reddit_title
@@ -1026,7 +1025,7 @@ async def confirm_send_mission_via_button(interaction: discord.Interaction, miss
         view.message = await interaction.original_response()
 
 
-async def prepare_for_gen_mission(interaction: discord.Interaction, mission_params):
+async def prepare_for_gen_mission(interaction: discord.Interaction, mission_params: MissionParams):
 
     """
     - check validity of inputs
@@ -1047,7 +1046,8 @@ async def prepare_for_gen_mission(interaction: discord.Interaction, mission_para
     print(f"Returnflag status: {mission_params.returnflag}")
 
     # check if the carrier can be found, exit gracefully if not
-    carrier_data = find_carrier(mission_params.carrier_name_search_term, CarrierDbFields.longname.name)
+    carrier_data = flexible_carrier_search_term(mission_params.carrier_name_search_term)
+    
     if not carrier_data:  # error condition
         carrier_error_embed = discord.Embed(
             description=f"❌ No carrier found for '**{mission_params.carrier_name_search_term}**'. Use `/owner` to see a list of your carriers. If it's not in the list, ask an Admin to add it for you.",

--- a/ptn/missionalertbot/modules/helpers.py
+++ b/ptn/missionalertbot/modules/helpers.py
@@ -543,20 +543,25 @@ async def _cc_name_string_check(interaction: discord.Interaction, channel_emoji,
     # PROCESS: check for valid emoji
     print(emoji.is_emoji(emoji_string))
     if not emoji.is_emoji(emoji_string) and not emoji_string == None:
-        embed = discord.Embed(description="❌ Invalid emoji supplied. Use a valid Unicode emoji from your emoji keyboard,"
-                                        f"or leave the field blank. **Discord custom emojis will not work**.", color=constants.EMBED_COLOUR_ERROR)
-        bu_link = Button(label="Full Emoji List", url="https://unicode.org/emoji/charts/full-emoji-list.html")
-        view = View()
-        view.add_item(bu_link)
-        return await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+        error = "Invalid emoji supplied. Use a valid Unicode emoji from your emoji keyboard, " \
+                "or leave the field blank. **Discord custom emojis will not work**"
+        print('Invalid emoji')
+        try:
+            raise CustomError(error)
+        except Exception as e:
+            return await on_generic_error(interaction, e)
 
     # PROCESS: remove unusable characters and render to lowercase
     stripped_channel_name = _regex_alphanumeric_with_hyphens(channel_name.lower())
 
     # check the channel name isn't too long
     if len(stripped_channel_name) > 30:
-        embed = discord.Embed(description="❌ Channel name should be fewer than 30 characters. (Preferably a *lot* fewer.)", color=constants.EMBED_COLOUR_ERROR)
-        return await interaction.response.send_message(embed=embed, ephemeral=True)
+        error = "Channel name should be fewer than 30 characters. (Preferably a *lot* fewer.)"
+        print('Channel name too long')
+        try:
+            raise CustomError(error)
+        except Exception as e:
+            return await on_generic_error(interaction, e)
 
     # join with the emoji
     new_channel_name = emoji_string + stripped_channel_name if not emoji_string == None else stripped_channel_name
@@ -628,8 +633,7 @@ async def _community_channel_owner_check(interaction):
         try:
             raise CustomError(error)
         except Exception as e:
-            await on_generic_error(interaction, e)
-        return
+            return await on_generic_error(interaction, e)
 
     elif community_carrier:
         print(f"Found data: {community_carrier.owner_id} owner of {community_carrier.channel_id}")

--- a/ptn/missionalertbot/modules/helpers.py
+++ b/ptn/missionalertbot/modules/helpers.py
@@ -693,6 +693,53 @@ def check_training_mode(interaction: discord.Interaction):
 
     return training, channel_defs
 
+# identify PTN carrier details from a string
+def extract_carrier_ident_strings(message: discord.Message):
+    """
+    Searches for matches to the format "PTN Carrier Name (IDX-NUM)
+
+    param message_content: the content of the message to search
+    returns: a list of matched pairs of name/ID
+    """
+    # regex to match the strings
+    pattern = r'(P\.?T\.?N\.?\s+[^)]+?)\s+\((\w{3}-\w{3})\)'
+    shortname_pattern = r'(P\.?T\.?N\.?)'
+
+    # find all matching occurrences in the message content
+    matches = re.findall(pattern, message.content)
+
+    # extract the matched strings into separate variables
+    extracted_strings = []
+
+    index = 0
+
+    # make sure each match is a pair
+    for match in matches:
+        if len(match) == 2:
+            ptn_string = str(match[0])
+            bracket_string = str(match[1])
+            print(f'Found matching pair in message: {ptn_string} ({bracket_string})')
+            # extract a shortname
+            shortname_string = re.sub(shortname_pattern, '', ptn_string)
+            shortname_string = shortname_string.lower().replace(" ", "")
+
+            # create a channel name
+            stripped_name = _regex_alphanumeric_with_hyphens(ptn_string).lower()
+
+            # attach to list as a dict
+            extracted_strings.append({
+                'index': index,
+                'long_name': ptn_string.upper(),
+                'carrier_id': bracket_string.upper(),
+                'short_name': shortname_string.lower(),
+                'channel_name': stripped_name.lower(),
+                'owner_id': message.author.id
+            })
+            index += 1
+        else:
+            print(f'Ignoring {match}: no pair found')
+
+    return extracted_strings
 
 # presently unused
 # TODO: remove or incorporate


### PR DESCRIPTION
New commands:
- [#579](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/579) `/cco active` - toggles Active status for CCOs; CCOs set to active this way will not have the role removed for at least 28 days. Permissions: CCO, Fleet Reserve.
- [#577](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/577) `/rename_community_channel` - used in a Community Channel to rename both the channel and the role. Permissions: Community Mentor, Community Channel Owner.
- [#597](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/597) `Add Carrier` - Context Menu -> Message. Attempts to match PTN carrier name/ID format from a message and give the option of adding them to the database. Permissions: Council.
- `/admin_opt_in` - List all CCO opt-ins. (This is for database maintenance purposes.) Permissions: Council. 

Other changes:
- [#578](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/578) `/cco load` `/cco unload` `/cco image` `/cco complete` will now accept any of the following as carrier search terms: full name partial string (as per default behaviour prior to 2.3.0); shortname; carrier registration (e.g. K8Y-T2G); carrier database entry number (discoverable via `/find`)
- [#596](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/596) Fixed TimeoutError -> asyncio.TimeoutError
- [#593](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/593) All Reddit interactions will now abandon and return appropriate errors after a certain amount of time
- More errors moved to error handler; better handling of certain errors
- [#588](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/588) Added cAPI information and ;stock inara command to local mission information embed, unless mission is flagged EDMC-OFF