### PR TITLE
2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,10 @@ CCO Wine load changes:
 - [#445](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/445) CCO Message Text will now display directly after BC wine loads as a temporary solution until [#20](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/20) is implemented, to allow posting of Wine + Tritium loads in #wine-cellar-loading
 - [#259](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/259) Wine alerts channel automatically selected based on BC status
 
-Error message changes:
+Other changes:
+- If a role ping is used by `/cco load` or `/cco unload`, the role's ID will be stored in mission_params. This makes mission editing more straightforward.
+- The trade alert channel used by `/cco load` and `/cco unload` is now stored in mission_params. This makes mission cleanup/editing more straightforward.
+- Version number at time of mission creation added to MissionParams to aid with future backwards compatibility tests.
 - [#596](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/596) Fixed TimeoutError -> asyncio.TimeoutError. TimeoutErrors now handled by ErrorHandler.py via their own error class.
 - More errors moved to error handler; better handling of certain errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,17 @@ CCO command behaviour changes:
 - [#588](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/588) Added cAPI information and ;stock inara command to local mission information embed, unless mission is flagged EDMC-OFF
 
 CCO Wine load changes:
+- Wine loads are now affected by the state of the Booze Cruise #wine-cellar-loading channel
+    - open is considered "BC active"
+        - a notice appears when posting a Wine load under BC conditions
+    - closed is considered "BC inactive"
+- Wine loads posted under BC inactive conditions are considered normal trades and will send to #official-trade-alerts
 - Wine loads are no longer prohibited from external sends
 - Wine loads no longer skip Hauler pings
-- Wine loads will now send to regular trade-alerts unless the #wine-cellar-loading channel is open, in which case it will use #wine-cellar-loading instead and notify the user that this will be the case
+    - BC Wine loads have the option to ping either the Hauler or BubbleWineLoader role. Default state is to ping neither.
 - EDMC-OFF option disabled for BC Wine loads
 - [#570](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/570) BC Wine load format changed to BC standard format
-        - BC Wine load alerts no longer use embeds
+    - BC Wine load alerts no longer use embeds
 - [#445](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/445) CCO Message Text will now display directly after BC wine loads as a temporary solution until [#20](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/20) is implemented, to allow posting of Wine + Tritium loads in #wine-cellar-loading
 - [#259](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/259) Wine alerts channel automatically selected based on BC status
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ CCO Wine load changes:
 - [#445](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/445) CCO Message Text will now display directly after BC wine loads as a temporary solution until [#20](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/20) is implemented, to allow posting of Wine + Tritium loads in #wine-cellar-loading
 - [#259](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/259) Wine alerts channel automatically selected based on BC status
 
-Other changes:
+Technical changes:
+- ChannelDefs now stored in classes/ChannelDefs.py and relevant type annotation added to MissionParams
+- More type annotation throughout
 - If a role ping is used by `/cco load` or `/cco unload`, the role's ID will be stored in mission_params. This makes mission editing more straightforward.
 - The trade alert channel used by `/cco load` and `/cco unload` is now stored in mission_params. This makes mission cleanup/editing more straightforward.
 - Version number at time of mission creation added to MissionParams to aid with future backwards compatibility tests.

--- a/ptn/missionalertbot/classes/ChannelDefs.py
+++ b/ptn/missionalertbot/classes/ChannelDefs.py
@@ -1,0 +1,12 @@
+# a class to hold channel definitions for training mode
+class ChannelDefs:
+    def __init__(self, category_actual, alerts_channel_actual, mission_command_channel_actual, upvotes_channel_actual, wine_loading_channel_actual, wine_unloading_channel_actual, sub_reddit_actual, reddit_flair_in_progress, reddit_flair_completed):
+        self.category_actual = category_actual
+        self.alerts_channel_actual = alerts_channel_actual
+        self.mission_command_channel_actual = mission_command_channel_actual
+        self.upvotes_channel_actual = upvotes_channel_actual
+        self.wine_loading_channel_actual = wine_loading_channel_actual
+        self.wine_unloading_channel_actual = wine_unloading_channel_actual
+        self.sub_reddit_actual = sub_reddit_actual
+        self.reddit_flair_in_progress = reddit_flair_in_progress
+        self.reddit_flair_completed = reddit_flair_completed

--- a/ptn/missionalertbot/classes/MissionParams.py
+++ b/ptn/missionalertbot/classes/MissionParams.py
@@ -1,4 +1,6 @@
 from ptn.missionalertbot.classes.CarrierData import CarrierData
+from ptn.missionalertbot.classes.ChannelDefs import ChannelDefs
+from ptn.missionalertbot._metadata import __version__
 
 class MissionParams:
     """
@@ -20,9 +22,12 @@ class MissionParams:
         else:
             info_dict = dict()
 
+        self.mission_version = info_dict.get('mission_version', __version__) # the version of MAB the mission was generated under
         self.returnflag: bool = info_dict.get('returnflag', True) # used in various places during mission gen to indicate an error if false
         self.training: bool = info_dict.get('training', False) # whether this is a training mission or not
-        self.channel_defs = info_dict.get('channel_defs', None) # defines channels used by mission generator
+        self.channel_defs: ChannelDefs = info_dict.get('channel_defs', None) # defines channels used by mission generator
+        self.channel_alerts_actual: int = info_dict.get('channel_alerts_actual', None) # ID of alerts channel used when sending mission, as defined from ChannelDefs
+        self.role_ping_actual: int = info_dict.get('channel_alerts_actual', None) # ID of role ping used by bot when sending mission
         self.copypaste_embed = info_dict.get('copypaste_embed', None) # embed containing the copy/paste string for the command used
         self.carrier_name_search_term: str = info_dict.get('carrier_name_search_term', None) # the carrier name fragment to search for
         self.commodity_search_term: str = info_dict.get('commodity_search_term', None) # the commodity name fragment to search for
@@ -65,9 +70,12 @@ class MissionParams:
 
     def print_values(self):
         try:
+            print(f"version: {self.version}")
             print(f"returnflag: {self.returnflag}")
             print(f"training: {self.training}")
             print(f"channel_defs: {self.channel_defs}")
+            print(f"channel_alerts_actual: {self.channel_alerts_actual}")
+            print(f"role_ping_actual: {self.role_ping_actual}")
             print(f"copypaste_embed: {self.copypaste_embed}")
             print(f"carrier_name_search_term: {self.carrier_name_search_term}")
             print(f"commodity_search_term: {self.commodity_search_term}")
@@ -125,9 +133,12 @@ class MissionParams:
         """
         return (
             "⏩ Mission Params:\n"
+            f"version: {self.version}\n"
             f"returnflag: {self.returnflag}\n"
             f"training: {self.training}\n"
             f"channel_defs: {self.channel_defs}\n"
+            f"channel_alerts_actual: {self.channel_alerts_actual}\n"
+            f"role_ping_actual: {self.role_ping_actual}\n"
             f"copypaste_embed: {self.copypaste_embed}\n"
             f"carrier_name_search_term: {self.carrier_name_search_term}\n"
             f"commodity_search_term: {self.commodity_search_term}\n"

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -96,6 +96,7 @@ PROD_RECRUIT_ROLE = 800681823575343116 # CCO Recruit role
 PROD_CPILLAR_ROLE = 863789660425027624 # Community Pillar role on live server
 PROD_DEV_ROLE = 812988180210909214 # Developer role ID on live
 PROD_MOD_ROLE = 813814494563401780 # Mod role ID on Live
+PROD_SOMM_ROLE = 838520893181263872 # Sommelier role ID on live
 PROD_VERIFIED_ROLE = 867820916331118622 # Verified Member
 PROD_EVENT_ORGANISER_ROLE = 1023296182639939594 # Event Organiser
 PROD_BOT_ROLE = 802523214809923596 # General Bot role on live (Robot Overlords)
@@ -144,6 +145,7 @@ TEST_CC_ROLE = 877220476827619399 # CC role on test server
 TEST_CC_CAT = 877108931699310592 # Community Carrier category on test server
 TEST_ADMIN_ROLE = 836367194979041351 # Bot Admin role on test server
 TEST_MOD_ROLE = 903292469049974845 # Mod role on test server
+TEST_SOMM_ROLE = 849907019502059530 # Sommeliers on test server
 TEST_CMENTOR_ROLE = 877586763672072193 # Community Mentor role on test server
 TEST_CERTCARRIER_ROLE = 822999970012463154 # Certified Carrier role on test server
 TEST_RESCARRIER_ROLE = 947520552766152744 # Fleet Reserve Carrier role on test server
@@ -393,6 +395,9 @@ def admin_role():
 
 def mod_role():
   return PROD_MOD_ROLE if _production else TEST_MOD_ROLE
+
+def somm_role():
+  return PROD_SOMM_ROLE if _production else TEST_SOMM_ROLE
 
 def cmentor_role():
   return PROD_CMENTOR_ROLE if _production else TEST_CMENTOR_ROLE

--- a/ptn/missionalertbot/modules/MissionCleaner.py
+++ b/ptn/missionalertbot/modules/MissionCleaner.py
@@ -49,27 +49,16 @@ async def _cleanup_completed_mission(interaction: discord.Interaction, mission_d
         
         print(status)
 
-        try: # for backwards compatibility with missions created before the new column was added
+        try:
             mission_params: MissionParams = mission_data.mission_params
             print("Found mission_params")
         except:
             print("No mission_params found, mission created pre-2.1.0?")
-
-        if not mission_params:
-            print("instantiating mission_params with channel defs")
-            # instantiate a fresh instance of mission params with just channel_defs for channel definitions
-            channel_defs = ChannelDefs(
-                trade_cat(),
-                trade_alerts_channel(),
-                mission_command_channel(),
-                channel_upvotes(),
-                wine_alerts_loading_channel(),
-                wine_alerts_unloading_channel(),
-                sub_reddit(),
-                reddit_flair_mission_start(),
-                reddit_flair_mission_stop()
-            )
-            mission_params = MissionParams(dict(channel_defs = channel_defs))
+            try:
+                error = 'No MissionParams found, unable to continue. Contact an Admin for manual mission cleanup.'
+                raise CustomError(error)
+            except Exception as e:
+                await on_generic_error(interaction, e)
 
         async with interaction.channel.typing():
             completed_mission_channel = bot.get_channel(mission_data.channel_id)

--- a/ptn/missionalertbot/modules/MissionEditor.py
+++ b/ptn/missionalertbot/modules/MissionEditor.py
@@ -369,7 +369,7 @@ async def edit_discord_alerts(interaction: discord.Interaction, mission_params: 
                 print("Checking for cco_message_text status...")
                 if mission_params.cco_message_text is not None: send_embeds.append(discord_embeds.owner_text_embed)
 
-                if mission_params.notify_msg_id: # TODO store role ID in params
+                if mission_params.notify_msg_id: 
                     if hasattr(mission_params, "booze_cruise"): # 2.3.0+
                         ping_role_id = mission_params.role_ping_actual
                     else: # pre-2.3.0 compatibility

--- a/ptn/missionalertbot/modules/MissionEditor.py
+++ b/ptn/missionalertbot/modules/MissionEditor.py
@@ -314,14 +314,20 @@ async def edit_discord_alerts(interaction: discord.Interaction, mission_params: 
             # get new trade alert message
             print("Create new alert text and embed")
             mission_params.discord_text = txt_create_discord(interaction, mission_params)
-            if not mission_params.booze_cruise:
+            if hasattr(mission_params, "booze_cruise"): # pre-2.3.0 backwards compatibility
+                if not mission_params.booze_cruise:
+                    embed = await return_discord_alert_embed(interaction, mission_params)
+            else:
                 embed = await return_discord_alert_embed(interaction, mission_params)
 
             # edit in new trade alert message
             if discord_alert_msg:
                 try:
                     print("Edit alert message")
-                    await discord_alert_msg.edit(content=mission_params.discord_text, suppress=True) if mission_params.booze_cruise else await discord_alert_msg.edit(embed=embed) 
+                    if hasattr(mission_params, "booze_cruise"): # pre-2.3.0 backwards compatibility
+                        await discord_alert_msg.edit(content=mission_params.discord_text, suppress=True) if mission_params.booze_cruise else await discord_alert_msg.edit(embed=embed) 
+                    else:
+                        await discord_alert_msg.edit(embed=embed) 
                 except Exception as e:
                     print(e)
                     embed=discord.Embed(description=f"Error editing discord alert: {e}", color=constants.EMBED_COLOUR_ERROR)

--- a/ptn/missionalertbot/modules/TextGen.py
+++ b/ptn/missionalertbot/modules/TextGen.py
@@ -26,16 +26,17 @@ TEXT GEN FUNCTIONS
 def txt_create_discord(interaction: Interaction, mission_params: MissionParams):
     discord_channel_id = mission_params.mission_temp_channel_id if mission_params.mission_temp_channel_id else mission_params.carrier_data.discord_channel
     discord_channel = f"<#{discord_channel_id}>"
-    if mission_params.booze_cruise:
-        # **[Carriername (CAR-IDX)]** | @[Cmdr Name] | [Loading System]/[Loading Station] - **[Amount of Wine]k** :wine_glass:+ **[Amount of Tritium]**:oil: @[Purchase Price of Tritium above Gal Avg]k/t
-        discord_text = (
-            f"{'**★ EDMC-OFF MISSION! ★** : ' if mission_params.edmc_off else ''}"
-            f"**[{mission_params.carrier_data.carrier_long_name}](https://discord.com/channels/{interaction.guild.id}/{discord_channel_id})** "
-            f"**({mission_params.carrier_data.carrier_identifier})** | "
-            f" <@{mission_params.carrier_data.ownerid}> | {mission_params.system.title()}/{mission_params.station.title()} - "
-            f"**{mission_params.demand}k :wine_glass:**"
-            f"{mission_params.cco_message_text if mission_params.cco_message_text else ''}"
-        )
+    if hasattr(mission_params, "booze_cruise"): # pre-2.3.0 backwards compatibility
+        if mission_params.booze_cruise:
+            # **[Carriername (CAR-IDX)]** | @[Cmdr Name] | [Loading System]/[Loading Station] - **[Amount of Wine]k** :wine_glass:+ **[Amount of Tritium]**:oil: @[Purchase Price of Tritium above Gal Avg]k/t
+            discord_text = (
+                f"{'**★ EDMC-OFF MISSION! ★** : ' if mission_params.edmc_off else ''}"
+                f"**[{mission_params.carrier_data.carrier_long_name}](https://discord.com/channels/{interaction.guild.id}/{discord_channel_id})** "
+                f"**({mission_params.carrier_data.carrier_identifier})** | "
+                f" <@{mission_params.carrier_data.ownerid}> | {mission_params.system.title()}/{mission_params.station.title()} - "
+                f"**{mission_params.demand}k :wine_glass:**"
+                f"{mission_params.cco_message_text if mission_params.cco_message_text else ''}"
+            )
 
     else:
         discord_text = (

--- a/ptn/missionalertbot/modules/helpers.py
+++ b/ptn/missionalertbot/modules/helpers.py
@@ -9,7 +9,6 @@ Depends on: constants, ErrorHandler, database
 import asyncio
 from datetime import datetime, timezone
 import emoji
-from functools import wraps
 import random
 import re
 import sys
@@ -19,9 +18,9 @@ import discord
 from discord import Interaction, app_commands
 from discord.errors import HTTPException, Forbidden, NotFound
 from discord.ext import commands
-from discord.ui import View, Button
 
 # import local classes
+from ptn.missionalertbot.classes.ChannelDefs import ChannelDefs
 from ptn.missionalertbot.classes.CommunityCarrierData import CommunityCarrierData
 
 # import local constants
@@ -665,19 +664,6 @@ def convert_str_to_float_or_int(element: any) -> bool: # this code turns a STR i
         print(f"We can't float {element}")
         return False
 
-
-# a class to hold channel definitions for training mode
-class ChannelDefs:
-    def __init__(self, category_actual, alerts_channel_actual, mission_command_channel_actual, upvotes_channel_actual, wine_loading_channel_actual, wine_unloading_channel_actual, sub_reddit_actual, reddit_flair_in_progress, reddit_flair_completed):
-        self.category_actual = category_actual
-        self.alerts_channel_actual = alerts_channel_actual
-        self.mission_command_channel_actual = mission_command_channel_actual
-        self.upvotes_channel_actual = upvotes_channel_actual
-        self.wine_loading_channel_actual = wine_loading_channel_actual
-        self.wine_unloading_channel_actual = wine_unloading_channel_actual
-        self.sub_reddit_actual = sub_reddit_actual
-        self.reddit_flair_in_progress = reddit_flair_in_progress
-        self.reddit_flair_completed = reddit_flair_completed
 
 # check whether CCO command is being used in training or live categories
 def check_training_mode(interaction: discord.Interaction):


### PR DESCRIPTION
- Move ChannelDefs to separate class
- More type annotation esp in MissionParams
- MissionParams now stores version, alerts channel ID, and role ping ID
- Removed pre-2.1.0 mission compatibility from Mission Editor
- Added backwards compatibility for pre-2.3.0 missions to Mission Editor
- BC Wine loads have the option to ping either the Hauler or BubbleWineLoader role. Default state is to ping neither.