### PR TITLE
Admin group command changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.3.8
+- All admin commands are now interactions in the 'admin' group:
+    - `/admin_release_channel_lock` is now `/admin lock release`
+    - `/admin_acquire_channel_lock` is now `/admin lock acquire`
+    - `m.cron_status` is now `/admin cron_status`
+    - `m.backup` is now `/admin backup`
+    - `m.stopquit` is now `/admin stopquit`
+    - `/admin_list_optins` is now `/admin list_cco_optins` and has moved to `GeneralCommands.py`
+    - `/admin_delete_mission` is now `/admin delete_mission` and has moved to `GeneralCommands.py`
+- Various cosmetic improvements to above commands
+- New commmand: `/admin lock list` - lists all active channel locks for debugging purposes
+
+
 ## 2.3.7a
 - Reverted `/carrier find` change because Discord is stupid
 

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.7a'
+__version__ = '2.3.8'

--- a/ptn/missionalertbot/modules/helpers.py
+++ b/ptn/missionalertbot/modules/helpers.py
@@ -167,6 +167,10 @@ def check_mission_channel_lock(channel):
         return False
 
 
+def list_active_locks():
+    return channel_locks
+
+
 # function to stop and quit
 def bot_exit():
     sys.exit("User requested exit.")


### PR DESCRIPTION
- All admin commands are now interactions in the 'admin' group: - `/admin_release_channel_lock` is now `/admin lock release` - `/admin_acquire_channel_lock` is now `/admin lock acquire` - `m.cron_status` is now `/admin cron_status` - `m.backup` is now `/admin backup` - `m.stopquit` is now `/admin stopquit` - `/admin_list_optins` is now `/admin list_cco_optins` and has moved to `GeneralCommands.py` - `/admin_delete_mission` is now `/admin delete_mission` and has moved to `GeneralCommands.py`
- Various cosmetic improvements to above commands
- New commmand: `/admin lock list` - lists all active channel locks for debugging purposes
- Version bump to 2.3.8