### PR TITLE
2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.3.8
+- All admin commands are now interactions in the 'admin' group:
+    - `/admin_release_channel_lock` is now `/admin lock release`
+    - `/admin_acquire_channel_lock` is now `/admin lock acquire`
+    - `m.cron_status` is now `/admin cron_status`
+    - `m.backup` is now `/admin backup`
+    - `m.stopquit` is now `/admin stopquit`
+    - `/admin_list_optins` is now `/admin list_cco_optins` and has moved to `GeneralCommands.py`
+    - `/admin_delete_mission` is now `/admin delete_mission` and has moved to `GeneralCommands.py`
+- Various cosmetic improvements to above commands
+- New commmand: `/admin lock list` - lists all active channel locks for debugging purposes
+
+
 ## 2.3.7a
 - Reverted `/carrier find` change because Discord is stupid
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.1
+- Fix for BC status not being detected on Live server
+
+
 ## 2.3.0
 New commands:
 - [#579](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/579) `/cco active` - toggles Active status for CCOs; CCOs set to active this way will not have the role removed for at least 28 days. Permissions: CCO, Fleet Reserve.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.3.3
+- [#620](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/620) `Add Carrier`'s initial response is now edited rather than deleted, to enhance clarity for observers.
+- [#619](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/619) `Add Carrier` now sends the stockbot command to #bot-commands, with a ping for the command user.
+- `Add Carrier` is now plural-aware.
+- [#621](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/621) Mission summary for `/cco load`, `/cco unload`, and `/cco edit` now uses the alert text instead of embed with fields.
+- Renamed `✍ Set Message` on `/cco edit` to `✍ Set or Remove Message`+
+- Removed the `🗑 Remove Message` button from `/cco edit` and conformed `✍ Set or Remove Message` behaviour to match `✍ Set Message` on `/cco load` and `/cco unload`. 
+- [#618](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/618) Bugfix: `build_directory_structure_on_startup()` now runs in `database.py` instead of `application.py`.
+- Bugfix: channel delete on mission gen failure will now be properly called with `seconds_short()`
+
+
 ## 2.3.2
 - Hotfix for missions not sending if user has no webhooks saved
 - Mission preview now uses trade alert preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.7
+- All database commands beginning with `carrier_` are now in the `carrier` subgroup, and can be accessed via `/carrier <command>`. This includes `add`, `delete`, `edit`, `purge`, and `find`.
+- `/find` is now `/carrier find`
+- [#571](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/571) New command: `/carrier purge`: lists carriers belonging to owners who are no longer on the server, with option to delete.
+
+
 ## 2.3.6
 - [#639](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/639) Automatically replace the letter "O" with zero when encountered in Fleet Carrier registrations to add to database
 - [#637](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/637) Discord invites sent by MAB to Reddit now use the direct link: `https://discord.gg/ptn`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.7a
+- Reverted `/carrier find` change because Discord is stupid
+
+
 ## 2.3.7
 - All database commands beginning with `carrier_` are now in the `carrier` subgroup, and can be accessed via `/carrier <command>`. This includes `add`, `delete`, `edit`, `purge`, and `find`.
 - `/find` is now `/carrier find`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.3.2
+- Hotfix for missions not sending if user has no webhooks saved
+- Mission preview now uses trade alert preview
+    - In BC state, message will show in preview embed
+- New graphics (thanks Sim!) to indicate load and unload, used in trade alerts and channel embeds
+- Setting EDMC-OFF disables incompatible buttons (i.e. Reddit, Webhooks)
+- Training mode Wine loads are always considered in BC state
+
+
 ## 2.3.1
 - Fix for BC status not being detected on Live server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.4
+- [#629](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/629) Shortnames created via `Add Carrier` will no longer include non-alphanumeric characters
+- [#628](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/628) `Add Carrier`'s confirmation buttons now include a check for which user is attempting the interaction
+- [#626](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/626) `Add Carrier`'s "Please wait..." message will now be updated upon completion.
+
+
 ## 2.3.3
 - [#620](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/620) `Add Carrier`'s initial response is now edited rather than deleted, to enhance clarity for observers.
 - [#619](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/619) `Add Carrier` now sends the stockbot command to #bot-commands, with a ping for the command user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 2.4.0
+Integrated stock tracking features from stockbot (with thanks to DudeInCorner and Durzo):
+- `/stock`:
+ - can be used in a carrier channel without parameters to check stock of that carrier.
+ - can be used with carrier as a parameter to check stock for any carrier.
+ - can optionally specify inara or capi as source; default is capi.
+ - added information in footer as to stock source.
+ - EDMC data notice is now context-sensitive:
+   - EDMC notice will only show when source is 'inara'.
+   - EDMC-off missions will show a reminder to disable EDMC, instead of the reminder to use it
+- `/cco capi enable`: If capi auth is confirmed, will flag the carrier(s) as capi-enabled; otherwise, will send the target carrier owner a DM with OAuth link and explanation. Multiple carriers can be separated by commas.
+- `/cco capi disable`: Will flag the carrier(s) as capi-disabled and prevent capi stock checks. Multiple carriers can be separated by commas.
+- Adding carriers to Mission Alert Bot will no longer prompt the user to add to stockbot.
+
+Integrated WMM tracking features from stockbot (with thanks to Durzo):
+- WMM stock display in #wmm-stock and #cco-wmm-supplies.
+- `/cco wmm enable`: Adds a carrier to WMM tracking; option to autocomplete station location from list.
+- `/cco wmm disable`: Removes one or more carriers from WMM tracking. Multiple carriers can be separated by commas.
+- `/cco wmm update`: Trigger manual refresh of all WMM stock.
+- `/admin wmm status`: Check the status of the WMM background task; now shows time remaining until next loop, as well as current interval time.
+- `/admin wmm stop`: Stop the WMM background task.
+- `/admin wmm start`: Start or restart the WMM background task.
+- `/admin wmm interval`: Set the WMM update interval in minutes.
+- `m.wmm_list`: List active WMM carriers.
+
+Other:
+- `/carrier add` and `Add Carrier` no longer offer StockBot code for `;add_FC`.
+- `/carrier add` no longer has a shortname field; all shortnames are now generated internally by MAB.
+- `/carrier add` can now be used in #CCO-general-chat
+- Changed references to `;stock <shortname>` to `/stock`.
+- Removed shortname as a user-facing variable.
+- Added cAPI status to carrier info embeds.
+- Trade Alerts will now include updated supply/demand remaining if a user uses `/stock` for a carrier on a mission.
+- Updated web links for loading/unloading images so Discord will finally stock mocking me with cached images from 3 months ago.
+- `/admin capi_sync`: Intended for first run after StockBot migration: updates CAPI status for all registered PTN Fleet Carriers.
+- Added initial `settings.txt` with option to disable WMM auto start and specific some command IDs; for now, only `/stock` is implemented:
+ - `/admin settings view` to view settings.txt;
+ - `/admin settings change` to change a setting in the file.
+
+
 ## 2.3.9
 - Add author check to interaction buttons for `/carrier purge`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2.3.6
+- [#635](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/635) `/cco load`, `unload`, and `edit` now properly use the target carrier's owner for all relevant purposes (including webhooks and trade alert 'author') instead of the interaction user
 - [#642](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/642) `spamchannel` now properly defined for failure state when member cannot be found during mission generation
 - [#642](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/642) `mission_temp_channel` now properly defined as `None` before `send_mission_to_discord()`, to avoid additional errors when said function returns early due to error
 - [#642](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/642) `find_mission` now properly returns `mission_data` as `None` if no mission is found, rather than a class filled entirely with `None`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.5
+- [#632](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/632) Removed footer of `Add Carrier` summary embed (no longer needed)
+
+
 ## 2.3.4
 - [#629](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/629) Shortnames created via `Add Carrier` will no longer include non-alphanumeric characters
 - [#628](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/628) `Add Carrier`'s confirmation buttons now include a check for which user is attempting the interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.3.6
+- [#642](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/642) `spamchannel` now properly defined for failure state when member cannot be found during mission generation
+- [#642](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/642) `mission_temp_channel` now properly defined as `None` before `send_mission_to_discord()`, to avoid additional errors when said function returns early due to error
+- [#642](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/642) `find_mission` now properly returns `mission_data` as `None` if no mission is found, rather than a class filled entirely with `None`
+- [#642](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/642) Channel lock release should now work properly if the mission generator stops because of an error
+- [#643](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/643) `/admin_release_channel_lock` and `/admin_acquire_channel_lock` now properly notify the user if the lock status is already as desired
+
+
 ## 2.3.5
 - [#632](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/632) Removed footer of `Add Carrier` summary embed (no longer needed)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,25 @@ New commands:
 - [#597](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/597) `Add Carrier` - Context Menu -> Message. Attempts to match PTN carrier name/ID format from a message and give the option of adding any matches to the database. Permissions: Council.
 - `/admin_opt_in` - List all CCO opt-ins. (This is for database maintenance purposes.) Permissions: Council. 
 
-Other changes:
+CCO command behaviour changes:
 - [#578](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/578) `/cco load` `/cco unload` `/cco image` `/cco complete` will now accept any of the following as carrier search terms: full name partial string (as per default behaviour prior to 2.3.0); shortname; carrier registration (e.g. K8Y-T2G); carrier database entry number (discoverable via `/find`)
 - `/cco load` `/cco unload` mission send select menu has been replaced with buttons:
-    - Buttons provide visual feedback as to which sends are seleted: enabled sends are blue, disabled are grey
+    - Buttons provide visual feedback as to which sends are seleted: selected sends are blue, deselected are grey, disabled are greyed out (faded and not clickable)
     - Default sends remain the same
     - Buttons can be clicked to toggle a send on/off
-    - Clicking the EDMC-OFF button will toggle the EDMC off option, and reset send options to default for the currently active profile (i.e. EDMC-OFF: ping, no external sends, EDMC-ON: ping, external sends)
-    - Clicking the Send button will send using all enabled sends, rather than sending to all by default
-    - Option to send to webhooks will be greyed out if user has no registered webhooks
+    - Clicking the "EDMC-OFF" button will toggle the EDMC-off option, and reset send options to default for the currently active profile (i.e. EDMC-OFF: ping, no external sends, EDMC-ON: ping, external sends)
+    - Clicking the "Send" button will send using all enabled sends, rather than sending to all by default
+    - Option to select Webhook sends will be greyed out if user has no registered webhooks
+    - External sends (Reddit, Webhooks) will be greyed out if profit is < 10k
+    - A warning will display when profit is < 10k
+    - "Notify Haulers" will be available but deselected by default if profit is < 10k
 - [#600](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/600) The 'Set Message' button for `/cco load` `/cco unload` `/cco edit` now remembers your message, if any. It can also be submitted blank to erase the currently-set message.
     - Better feedback from 'Set Message': The message will now display continuously after being set, rather than disappearing if the user changes options.
+- `/cco edit` will now re-send Discord alerts and messages if found to be missing
+- [#593](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/593) All Reddit interactions will now abandon and return appropriate errors after a certain amount of time
+- [#588](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/588) Added cAPI information and ;stock inara command to local mission information embed, unless mission is flagged EDMC-OFF
+
+CCO Wine load changes:
 - Wine loads are no longer prohibited from external sends
 - Wine loads no longer skip Hauler pings
 - Wine loads will now send to regular trade-alerts unless the #wine-cellar-loading channel is open, in which case it will use #wine-cellar-loading instead and notify the user that this will be the case
@@ -25,10 +33,11 @@ Other changes:
 - [#570](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/570) BC Wine load format changed to BC standard format
         - BC Wine load alerts no longer use embeds
 - [#445](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/445) CCO Message Text will now display directly after BC wine loads as a temporary solution until [#20](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/20) is implemented, to allow posting of Wine + Tritium loads in #wine-cellar-loading
+- [#259](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/259) Wine alerts channel automatically selected based on BC status
+
+Error message changes:
 - [#596](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/596) Fixed TimeoutError -> asyncio.TimeoutError. TimeoutErrors now handled by ErrorHandler.py via their own error class.
-- [#593](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/593) All Reddit interactions will now abandon and return appropriate errors after a certain amount of time
 - More errors moved to error handler; better handling of certain errors
-- [#588](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/588) Added cAPI information and ;stock inara command to local mission information embed, unless mission is flagged EDMC-OFF
 
 
 ## 2.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,26 @@ CCO command behaviour changes:
 - [#588](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/588) Added cAPI information and ;stock inara command to local mission information embed, unless mission is flagged EDMC-OFF
 
 CCO Wine load changes:
+- Wine loads are now affected by the state of the Booze Cruise #wine-cellar-loading channel
+    - open is considered "BC active"
+        - a notice appears when posting a Wine load under BC conditions
+    - closed is considered "BC inactive"
+- Wine loads posted under BC inactive conditions are considered normal trades and will send to #official-trade-alerts
 - Wine loads are no longer prohibited from external sends
 - Wine loads no longer skip Hauler pings
-- Wine loads will now send to regular trade-alerts unless the #wine-cellar-loading channel is open, in which case it will use #wine-cellar-loading instead and notify the user that this will be the case
+    - BC Wine loads have the option to ping either the Hauler or BubbleWineLoader role. Default state is to ping neither.
 - EDMC-OFF option disabled for BC Wine loads
 - [#570](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/570) BC Wine load format changed to BC standard format
-        - BC Wine load alerts no longer use embeds
+    - BC Wine load alerts no longer use embeds
 - [#445](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/445) CCO Message Text will now display directly after BC wine loads as a temporary solution until [#20](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/20) is implemented, to allow posting of Wine + Tritium loads in #wine-cellar-loading
 - [#259](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/259) Wine alerts channel automatically selected based on BC status
 
-Error message changes:
+Technical changes:
+- ChannelDefs now stored in classes/ChannelDefs.py and relevant type annotation added to MissionParams
+- More type annotation throughout
+- If a role ping is used by `/cco load` or `/cco unload`, the role's ID will be stored in mission_params. This makes mission editing more straightforward.
+- The trade alert channel used by `/cco load` and `/cco unload` is now stored in mission_params. This makes mission cleanup/editing more straightforward.
+- Version number at time of mission creation added to MissionParams to aid with future backwards compatibility tests.
 - [#596](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/596) Fixed TimeoutError -> asyncio.TimeoutError. TimeoutErrors now handled by ErrorHandler.py via their own error class.
 - More errors moved to error handler; better handling of certain errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2.3.6
+- [#637](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/637) Discord invites sent by MAB to Reddit now use the direct link: `https://discord.gg/ptn`
 - [#635](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/635) `/cco load`, `unload`, and `edit` now properly use the target carrier's owner for all relevant purposes (including webhooks and trade alert 'author') instead of the interaction user
 - [#642](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/642) `spamchannel` now properly defined for failure state when member cannot be found during mission generation
 - [#642](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/642) `mission_temp_channel` now properly defined as `None` before `send_mission_to_discord()`, to avoid additional errors when said function returns early due to error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.9
+- Add author check to interaction buttons for `/carrier purge`
+
+
 ## 2.3.8
 - All admin commands are now interactions in the 'admin' group:
     - `/admin_release_channel_lock` is now `/admin lock release`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ CCO Wine load changes:
     - closed is considered "BC inactive"
 - Wine loads posted under BC inactive conditions are considered normal trades and will send to #official-trade-alerts
 - Wine loads are no longer prohibited from external sends
-- Wine loads no longer skip Hauler pings
-    - BC Wine loads have the option to ping either the Hauler or BubbleWineLoader role. Default state is to ping neither.
+- Non-BC Wine loads no longer skip Hauler pings
+    - Pings are disabled for BC Wine loads
 - EDMC-OFF option disabled for BC Wine loads
 - [#570](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/570) BC Wine load format changed to BC standard format
     - BC Wine load alerts no longer use embeds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2.3.6
+- [#639](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/639) Automatically replace the letter "O" with zero when encountered in Fleet Carrier registrations to add to database
 - [#637](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/637) Discord invites sent by MAB to Reddit now use the direct link: `https://discord.gg/ptn`
 - [#635](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/635) `/cco load`, `unload`, and `edit` now properly use the target carrier's owner for all relevant purposes (including webhooks and trade alert 'author') instead of the interaction user
 - [#642](https://github.com/PilotsTradeNetwork/MissionAlertBot/issues/642) `spamchannel` now properly defined for failure state when member cannot be found during mission generation

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.1'
+__version__ = '2.3.2'

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.7a'
+__version__ = '2.3.8'

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.0'
+__version__ = '2.3.1'

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.3'
+__version__ = '2.3.4'

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.2'
+__version__ = '2.3.3'

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.7'
+__version__ = '2.3.7a'

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.6'
+__version__ = '2.3.7'

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.8'
+__version__ = '2.3.9'

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.4'
+__version__ = '2.3.5'

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.9'
+__version__ = '2.4.0'

--- a/ptn/missionalertbot/_metadata.py
+++ b/ptn/missionalertbot/_metadata.py
@@ -1,2 +1,2 @@
 # version is BREAKING CHANGE - MAJOR CHANGE - MINOR CHANGE
-__version__ = '2.3.5'
+__version__ = '2.3.6'

--- a/ptn/missionalertbot/application.py
+++ b/ptn/missionalertbot/application.py
@@ -15,6 +15,7 @@ from ptn.missionalertbot.botcommands.GeneralCommands import GeneralCommands
 from ptn.missionalertbot.botcommands.CCOCommands import CCOCommands
 from ptn.missionalertbot.botcommands.CTeamCommands import CTeamCommands
 from ptn.missionalertbot.botcommands.DatabaseInteraction import DatabaseInteraction
+from ptn.missionalertbot.botcommands.StockTracker import StockTracker
 
 # import bot object, token, production status
 from ptn.missionalertbot.constants import bot, TOKEN, _production, DATA_DIR
@@ -36,6 +37,7 @@ async def missionalertbot():
         await bot.add_cog(CCOCommands(bot))
         await bot.add_cog(CTeamCommands(bot))
         await bot.add_cog(DatabaseInteraction(bot))
+        await bot.add_cog(StockTracker(bot))
         await bot.start(TOKEN)
 
 

--- a/ptn/missionalertbot/application.py
+++ b/ptn/missionalertbot/application.py
@@ -8,9 +8,7 @@ import asyncio
 import os
 
 # import build functions
-from ptn.missionalertbot.database.database import build_database_on_startup, build_directory_structure_on_startup, populate_commodities_table_on_startup
-
-build_directory_structure_on_startup() # build directory structure
+from ptn.missionalertbot.database.database import build_database_on_startup, populate_commodities_table_on_startup
 
 # import bot Cogs
 from ptn.missionalertbot.botcommands.GeneralCommands import GeneralCommands

--- a/ptn/missionalertbot/botcommands/CCOCommands.py
+++ b/ptn/missionalertbot/botcommands/CCOCommands.py
@@ -255,7 +255,7 @@ class CCOCommands(commands.Cog):
         training, channel_defs = check_training_mode(interaction)
 
         cp_embed = discord.Embed(
-            title="COPY/PASTE TEXT FOR THIS COMMAND",
+            title="📋 COPY/PASTE TEXT FOR THIS COMMAND",
             description=f"```/cco load carrier:{carrier} commodity:{commodity} system:{system} station:{station}"
                         f" profit:{profit} pads:{pads} demand:{demand}```",
             color=constants.EMBED_COLOUR_QU
@@ -311,7 +311,7 @@ class CCOCommands(commands.Cog):
         training, channel_defs = check_training_mode(interaction)
 
         cp_embed = discord.Embed(
-            title="COPY/PASTE TEXT FOR THIS COMMAND",
+            title="📋 COPY/PASTE TEXT FOR THIS COMMAND",
             description=f"```/cco unload carrier:{carrier} commodity:{commodity} system:{system} station:{station}"
                         f" profit:{profit} pads:{pads} supply:{supply}```",
             color=constants.EMBED_COLOUR_QU

--- a/ptn/missionalertbot/botcommands/CCOCommands.py
+++ b/ptn/missionalertbot/botcommands/CCOCommands.py
@@ -17,7 +17,7 @@ from discord.ext.commands import GroupCog
 # import local constants
 import ptn.missionalertbot.constants as constants
 from ptn.missionalertbot.constants import bot, mission_command_channel, certcarrier_role, trainee_role, seconds_long, rescarrier_role, commodities_common, \
-    bot_spam_channel, training_mission_command_channel, seconds_very_short, admin_role, mod_role, cco_mentor_role, aco_role, recruit_role
+    bot_spam_channel, training_mission_command_channel, seconds_very_short, admin_role, mod_role, cco_mentor_role, aco_role, recruit_role, cco_color_role
 
 # import local classes
 from ptn.missionalertbot.classes.MissionParams import MissionParams
@@ -111,6 +111,7 @@ async def toggle_cco(interaction:  discord.Interaction, member: discord.Member):
 
     member_roles = member.roles
     cco_role = discord.utils.get(interaction.guild.roles, id=certcarrier_role())
+    color_cco_role = discord.utils.get(interaction.guild.roles, id=cco_color_role())
     reserve_role = discord.utils.get(interaction.guild.roles, id=rescarrier_role())
     aco_role_object = discord.utils.get(interaction.guild.roles, id=aco_role())
     trainee_role_object = discord.utils.get(interaction.guild.roles, id=trainee_role())
@@ -121,7 +122,7 @@ async def toggle_cco(interaction:  discord.Interaction, member: discord.Member):
         print("Member does not already have role, checking user is sure about granting...")
 
         try:
-            roles = [cco_role, reserve_role]
+            roles = [cco_role, reserve_role, color_cco_role]
             remove_roles = [aco_role_object, trainee_role_object, recruit_role_object]
             view = ConfirmGrantRoleView(member, roles, remove_roles)
 
@@ -523,6 +524,7 @@ class CCOCommands(commands.Cog):
             # check if they have the CCO role
             print("⏳ Checking for CCO role...")
             cco_role = discord.utils.get(interaction.guild.roles, id=certcarrier_role())
+            color_cco_role = discord.utils.get(interaction.guild.roles, id=cco_color_role())
             if cco_role in interaction.user.roles:
                 print("▶ CCO role found. Transitioning user to inactive status.")
                 # check they have the Fleet Reserve role
@@ -534,6 +536,11 @@ class CCOCommands(commands.Cog):
                 # remove the CCO role
                 print("▶ Removing CCO role")
                 await interaction.user.remove_roles(cco_role)
+
+                # check for color role
+                if color_cco_role in interaction.user.roles:
+                    print("▶ Removing color role")
+                    await interaction.user.remove_roles(color_cco_role)
                 embed.description = f'💤 **Removed your <@&{cco_role.id}>** role. You are now marked inactive in the <@&{reserve_role.id}>.'
                 embed.set_footer(text='You can return to active status at any time by using this command again.')
                 embed.color = constants.EMBED_COLOUR_OK
@@ -541,6 +548,7 @@ class CCOCommands(commands.Cog):
             else:
                 print("▶ No CCO role found. Transitioning user to active status.")
                 await interaction.user.add_roles(cco_role)
+                await interaction.user.add_roles(color_cco_role)
                 print("✅ Granted CCO role.")
 
                 # check if user has an opt-in entry yet

--- a/ptn/missionalertbot/botcommands/CCOCommands.py
+++ b/ptn/missionalertbot/botcommands/CCOCommands.py
@@ -157,7 +157,7 @@ async def cco_mission_complete(interaction, carrier, is_complete, message):
         f'{current_channel}')
 
     # resolve the carrier from the carriers db
-    carrier_data = carrier_data = flexible_carrier_search_term(carrier)
+    carrier_data = flexible_carrier_search_term(carrier)
     if not carrier_data:  # error condition
         try:
             error = f"No carrier found for '**{carrier}**.'"
@@ -373,7 +373,7 @@ class CCOCommands(commands.Cog):
             # find the target carrier
             print("Looking for carrier data")
             try:
-                carrier_data = find_carrier(carrier, CarrierDbFields.longname.name)
+                carrier_data = flexible_carrier_search_term(carrier)
                 if not carrier_data:
                     raise CustomError(f"No carrier found matching {carrier}.")
             except CustomError as e:

--- a/ptn/missionalertbot/botcommands/DatabaseInteraction.py
+++ b/ptn/missionalertbot/botcommands/DatabaseInteraction.py
@@ -67,7 +67,11 @@ async def add_carrier(interaction:  discord.Interaction, message: discord.Messag
         owner_id = details['owner_id']
         channel_name = details['channel_name']
         print(f"Index {index} is '{long_name}' ({carrier_id}) with generated shortname {short_name}")
-        embed.add_field(name=f'Match {index+1}', value=f'Longname: `{long_name}` • Shortname: `{short_name}` • ID: `{carrier_id}` • Owner: <@{owner_id}> • ChannelName: #`{channel_name}`', inline=False)
+        embed.add_field(
+            name=f"{f'Match {index+1}' if len(carrier_details) > 1 else 'Matched Details'}",
+            value=f'Longname: `{long_name}` • Shortname: `{short_name}` • ID: `{carrier_id}` • Owner: <@{owner_id}> • ChannelName: #`{channel_name}`',
+            inline=False
+        )
 
     # TODO check no two fields are identical
 

--- a/ptn/missionalertbot/botcommands/DatabaseInteraction.py
+++ b/ptn/missionalertbot/botcommands/DatabaseInteraction.py
@@ -78,7 +78,7 @@ async def add_carrier(interaction:  discord.Interaction, message: discord.Messag
     embed.title="🔎 CARRIER DETAILS FOUND IN MESSAGE"
     embed.description=None
 
-    view = AddCarrierButtons(message, carrier_details)
+    view = AddCarrierButtons(message, carrier_details, interaction.user)
 
     await interaction.edit_original_response(embed=embed, view=view)
     view.message = await interaction.original_response()

--- a/ptn/missionalertbot/botcommands/DatabaseInteraction.py
+++ b/ptn/missionalertbot/botcommands/DatabaseInteraction.py
@@ -697,9 +697,9 @@ class DatabaseInteraction(commands.Cog):
     # slash version of m.find, private
     # TODO: replace with broadcast option
     # TODO: implement multiple result logic from m.find
-    @carrier_group.command(name="find",
+    @app_commands.command(name="find",
                           description="Private command: Search for a fleet carrier by partial match for its name.")
-    @describe(carrier_name_search_term='Part of the full name of the carrier you wish to find.')
+    @app_commands.describe(carrier_name_search_term='Part of the full name of the carrier you wish to find.')
     async def _find(self, interaction: discord.Interaction, carrier_name_search_term: str):
         print(f"{interaction.user} used /find for '{carrier_name_search_term}' in {interaction.channel}")
 

--- a/ptn/missionalertbot/botcommands/DatabaseInteraction.py
+++ b/ptn/missionalertbot/botcommands/DatabaseInteraction.py
@@ -21,17 +21,19 @@ from ptn.missionalertbot.classes.CarrierData import CarrierData
 from ptn.missionalertbot.classes.CommunityCarrierData import CommunityCarrierData
 from ptn.missionalertbot.classes.NomineesData import NomineesData
 from ptn.missionalertbot.classes.Views import db_delete_View, BroadcastView, CarrierEditView, MissionDeleteView, AddCarrierButtons, ConfirmPurgeView
+from ptn.missionalertbot.classes.WMMData import WMMData
 
 # local constants
 import ptn.missionalertbot.constants as constants
 from ptn.missionalertbot.constants import bot, cmentor_role, admin_role, cteam_bot_channel, cteam_bot_channel, bot_command_channel, cc_role, \
-    admin_role, mod_role, bot_spam_channel, fc_complete_emoji, get_guild
+    admin_role, mod_role, bot_spam_channel, fc_complete_emoji, get_guild, channel_cco_general_chat
 
 # local modules
 from ptn.missionalertbot.database.database import find_nominee_with_id, carrier_db, CarrierDbFields, find_carrier, backup_database, \
-    add_carrier_to_database, find_carriers_mult, find_commodity, find_community_carrier, CCDbFields
+    add_carrier_to_database, find_carriers_mult, find_commodity, find_community_carrier, CCDbFields, wmm_db
 from ptn.missionalertbot.modules.ErrorHandler import on_app_command_error, CustomError, on_generic_error, GenericError
-from ptn.missionalertbot.modules.helpers import check_roles, check_command_channel, _regex_alphanumeric_with_hyphens, extract_carrier_ident_strings
+from ptn.missionalertbot.modules.helpers import check_roles, check_command_channel, _regex_alphanumeric_with_hyphens, extract_carrier_ident_strings, \
+    _regex_alphanumeric_only
 from ptn.missionalertbot.modules.Embeds import _add_common_embed_fields, _configure_all_carrier_detail_embed, orphaned_carrier_summary_embed
 
 
@@ -351,13 +353,12 @@ class DatabaseInteraction(commands.Cog):
 
     # add FC to database
     @carrier_group.command(name='add', description='Add a Fleet Carrier to the database.')
-    @describe(short_name='The name used by the ;stock command.',
-                           long_name='The full name of the Fleet Carrier (will be converted to UPPERCASE).',
-                           carrier_id='The carrier\'s registration in the format XXX-XXX.',
-                           owner_id='The Discord ID of the carrier\'s owner.')
+    @describe(full_name='The full name of the Fleet Carrier (will be converted to UPPERCASE).',
+              carrier_id='The carrier\'s registration in the format XXX-XXX.',
+              owner_id='The Discord ID of the carrier\'s owner.')
     @check_roles([admin_role()])
-    @check_command_channel(bot_command_channel())
-    async def add(self, interaction: discord.Interaction, short_name: str, long_name: str, carrier_id: str, owner_id: str):
+    @check_command_channel([bot_command_channel(), channel_cco_general_chat()])
+    async def add(self, interaction: discord.Interaction, full_name: str, carrier_id: str, owner_id: str):
 
         # check the ID code is correct format (thanks boozebot code!)
         if not re.match(r"\w{3}-\w{3}", carrier_id):
@@ -377,20 +378,25 @@ class DatabaseInteraction(commands.Cog):
 
         # Only add to the carrier DB if it does not exist, if it does exist then the user should not be adding it.
         # TODO: merge with Add Carrier
-        carrier_data = find_carrier(long_name, CarrierDbFields.longname.name)
+        carrier_data = find_carrier(full_name, CarrierDbFields.longname.name)
         if carrier_data:
             # Carrier exists already, go skip it.
-            print(f'Request recieved from {interaction.user} to add a carrier that already exists in the database ({long_name}).')
+            print(f'Request recieved from {interaction.user} to add a carrier that already exists in the database ({full_name}).')
 
             embed = discord.Embed(title="Fleet carrier already exists, use /carrier_edit to change its details.",
-                                description=f"Carrier data matched for {long_name}", color=constants.EMBED_COLOUR_OK)
+                                description=f"Carrier data matched for {full_name}", color=constants.EMBED_COLOUR_OK)
             embed = _add_common_embed_fields(embed, carrier_data, interaction)
             return await interaction.response.send_message(embed=embed, ephemeral=True)
 
         backup_database('carriers')  # backup the carriers database before going any further
 
-        # now generate a string to use for the carrier's channel name based on its long name
-        stripped_name = _regex_alphanumeric_with_hyphens(long_name)
+        # now generate a string to use for the carrier's channel name based on its full (long) name
+        stripped_name = _regex_alphanumeric_with_hyphens(full_name)
+
+        # generate a shortname from the stripped fullname
+        shortname_pattern = r'(P\.?T\.?N\.?)'
+        shortname_string = re.sub(shortname_pattern, '', stripped_name)
+        short_name = _regex_alphanumeric_only(shortname_string)
 
         # find carrier owner as a user object so we know they're a valid user
         # TODO: move error to handler
@@ -402,22 +408,14 @@ class DatabaseInteraction(commands.Cog):
 
         # finally, send all the info to the db
         # TODO: merge with Add Carrier
-        await add_carrier_to_database(short_name.lower(), long_name.upper(), carrier_id.upper(), stripped_name.lower(), 0, owner_id)
+        await add_carrier_to_database(short_name.lower(), full_name.upper(), carrier_id.upper(), stripped_name.lower(), 0, owner_id)
 
-        carrier_data = find_carrier(long_name, CarrierDbFields.longname.name)
+        carrier_data = find_carrier(full_name, CarrierDbFields.longname.name)
         info_embed = discord.Embed(title="Fleet Carrier successfully added to database",
                             color=constants.EMBED_COLOUR_OK)
         info_embed = _add_common_embed_fields(info_embed, carrier_data, interaction)
 
-        cp_embed = discord.Embed(
-            title="Copy/Paste code for Stockbot",
-            description=f"```;add_FC {carrier_data.carrier_identifier} {carrier_data.carrier_short_name} {carrier_data.ownerid}```",
-            color=constants.EMBED_COLOUR_QU
-        )
-
-        embeds = [info_embed, cp_embed]
-
-        await interaction.response.send_message(embeds=embeds)
+        await interaction.response.send_message(embed=info_embed)
 
         # notify bot-spam
         spamchannel: discord.TextChannel = bot.get_channel(bot_spam_channel())
@@ -612,9 +610,130 @@ class DatabaseInteraction(commands.Cog):
                     await message.remove_reaction(reaction, user)
 
             except asyncio.TimeoutError:
-                if ctx.fetch_message(message.id) and ctx.fetch_message(ctx.message.id):
+                if await ctx.fetch_message(message.id) and await ctx.fetch_message(ctx.message.id):
                     print(f'Timeout hit during carrier request by: {ctx.author}')
                     embed = discord.Embed(description=f'Closed the active carrier list request from {ctx.author} due to no input in 60 seconds.', color=constants.EMBED_COLOUR_QU)
+                    await ctx.send(embed=embed)
+                    await message.delete()
+                    await ctx.message.delete()
+                    break
+                else:
+                    return
+
+    # list WMM FCs
+    # TODO: slashify, new list logic
+    @commands.command(name='wmm_list', help='List all Fleet Carriers active in WMM supply. This times out after 60 seconds')
+    @commands.has_any_role(*constants.any_elevated_role)
+    async def wmm_list(self, ctx):
+
+        print(f'WMM list requested by user: {ctx.author}')
+
+        wmm_db.execute(f"SELECT * FROM wmm")
+        carriers = [WMMData(carrier) for carrier in wmm_db.fetchall()]
+
+        carrier: WMMData
+
+        def chunk(chunk_list, max_size=10):
+            """
+            Take an input list, and an expected max_size.
+
+            :returns: A chunked list that is yielded back to the caller
+            :rtype: iterator
+            """
+            for i in range(0, len(chunk_list), max_size):
+                yield chunk_list[i:i + max_size]
+
+        def validate_response(react, user):
+            return user == ctx.author and str(react.emoji) in ["◀️", "❌", "▶️"]
+            # This makes sure nobody except the command sender can interact with the "menu"
+
+        # TODO: should pages just be a list of embed_fields we want to add?
+        pages = [page for page in chunk(carriers)]
+
+        max_pages = len(pages)
+        current_page = 1
+
+        embed = discord.Embed(title=f"{len(carriers)} Active WMM Fleet Carriers Page:#{current_page} of {max_pages}")
+        count = 0   # Track the overall count for all carriers
+        # Go populate page 0 by default
+        for carrier in pages[0]:
+            count += 1
+            embed.add_field(name=f"{count}: {carrier.carrier_name} ({carrier.carrier_identifier})",
+                            value=f"Location: {carrier.carrier_location} CAPI: {carrier.capi}", inline=False)
+        # Now go send it and wait on a reaction
+        message = await ctx.send(embed=embed)
+
+        await message.add_reaction("❌")
+        # From page 0 we can only go forwards
+        if not current_page == max_pages: await message.add_reaction("▶️")
+
+        # 60 seconds time out gets raised by Asyncio
+        while True:
+            try:
+                reaction, user = await bot.wait_for('reaction_add', timeout=60, check=validate_response)
+                if str(reaction.emoji) == "❌":
+                    print(f'Closed list carrier request by: {ctx.author}')
+                    embed = discord.Embed(description=f'Closed the active carrier list.', color=constants.EMBED_COLOUR_OK)
+                    await ctx.send(embed=embed)
+                    await message.delete()
+                    await ctx.message.delete()
+                    return
+
+                elif str(reaction.emoji) == "▶️" and current_page != max_pages:
+                    print(f'{ctx.author} requested to go forward a page.')
+                    current_page += 1   # Forward a page
+                    new_embed = discord.Embed(title=f"{len(carriers)} Active WMM Fleet Carriers Page:{current_page}")
+                    for carrier in pages[current_page-1]:
+                        # Page -1 as humans think page 1, 2, but python thinks 0, 1, 2
+                        count += 1
+                        new_embed.add_field(name=f"{count}: {carrier.carrier_name} ({carrier.carrier_identifier})",
+                            value=f"Location: {carrier.carrier_location} CAPI: {carrier.capi}", inline=False)
+
+                    await message.edit(embed=new_embed)
+
+                    # Ok now we can go back, check if we can also go forwards still
+                    if current_page == max_pages:
+                        await message.clear_reaction("▶️")
+
+                    await message.remove_reaction(reaction, user)
+                    await message.add_reaction("◀️")
+
+                elif str(reaction.emoji) == "◀️" and current_page > 1:
+                    print(f'{ctx.author} requested to go back a page.')
+                    current_page -= 1   # Go back a page
+
+                    new_embed = discord.Embed(title=f"{len(carriers)} Active WMM Fleet Carriers Page:{current_page}")
+                    # Start by counting back however many carriers are in the current page, minus the new page, that way
+                    # when we start a 3rd page we don't end up in problems
+                    count -= len(pages[current_page - 1])
+                    count -= len(pages[current_page])
+
+                    for carrier in pages[current_page - 1]:
+                        # Page -1 as humans think page 1, 2, but python thinks 0, 1, 2
+                        count += 1
+                        new_embed.add_field(name=f"{count}: {carrier.carrier_name} ({carrier.carrier_identifier})",
+                            value=f"Location: {carrier.carrier_location} CAPI: {carrier.capi}", inline=False)
+
+                    await message.edit(embed=new_embed)
+                    # Ok now we can go forwards, check if we can also go backwards still
+                    if current_page == 1:
+                        await message.clear_reaction("◀️")
+
+                    await message.remove_reaction(reaction, user)
+                    await message.add_reaction("▶️")
+                else:
+                    # It should be impossible to hit this part, but lets gate it just in case.
+                    print(f'HAL9000 error: {ctx.author} ended in a random state while trying to handle: {reaction.emoji} '
+                        f'and on page: {current_page}.')
+                    # HAl-9000 error response.
+                    error_embed = discord.Embed(title=f"I'm sorry {ctx.author.name}, I'm afraid I can't do that.")
+                    await message.edit(embed=error_embed)
+                    await message.remove_reaction(reaction, user)
+
+            except asyncio.TimeoutError:
+                if await ctx.fetch_message(message.id) and await ctx.fetch_message(ctx.message.id):
+                    print(f'Timeout hit during WMM carrier request by: {ctx.author}')
+                    embed = discord.Embed(description=f'Closed the active WMM carrier list request from {ctx.author} due to no input in 60 seconds.', color=constants.EMBED_COLOUR_QU)
                     await ctx.send(embed=embed)
                     await message.delete()
                     await ctx.message.delete()

--- a/ptn/missionalertbot/botcommands/DatabaseInteraction.py
+++ b/ptn/missionalertbot/botcommands/DatabaseInteraction.py
@@ -66,6 +66,12 @@ async def add_carrier(interaction:  discord.Interaction, message: discord.Messag
         index = details['index']
         owner_id = details['owner_id']
         channel_name = details['channel_name']
+
+        # replace the letter 'O' with the number '0'
+        if "o" in carrier_id.lower():
+            carrier_id = carrier_id.replace("O", "0").replace("o", "0")
+
+
         print(f"Index {index} is '{long_name}' ({carrier_id}) with generated shortname {short_name}")
         embed.add_field(
             name=f"{f'Match {index+1}' if len(carrier_details) > 1 else 'Matched Details'}",
@@ -294,6 +300,10 @@ class DatabaseInteraction(commands.Cog):
         if not re.match(r"\w{3}-\w{3}", carrier_id):
             print(f'{interaction.user}, the carrier ID was invalid, XXX-XXX expected received, {carrier_id}.')
             return await interaction.response.send_message(f'ERROR: Invalid carrier ID. Expected: XXX-XXX, received `{carrier_id}`.', ephemeral=True)
+
+        # replace the letter 'O' with the number '0'
+        if "o" in carrier_id.lower():
+            carrier_id = carrier_id.replace("O", "0").replace("o", "0")
 
         # convert owner_id to int (slash commands have a cannot exceed the integer size limit, so we have to pass IDs as strings)
         # and check it is valid

--- a/ptn/missionalertbot/botcommands/GeneralCommands.py
+++ b/ptn/missionalertbot/botcommands/GeneralCommands.py
@@ -212,6 +212,7 @@ class GeneralCommands(commands.Cog):
                 description=f"No lock found for `{channelname}`.",
                 color=constants.EMBED_COLOUR_ERROR
             )
+            await interaction.response.send_message(embed=embed)
 
         else:
             try:
@@ -248,6 +249,7 @@ class GeneralCommands(commands.Cog):
                 description=f"🔒 `{channelname}` lock is already acquired. Check <#{bot_spam_channel()}> for details.",
                 color=constants.EMBED_COLOUR_ERROR
             )
+            await interaction.response.send_message(embed=embed)
 
         else:
             try:

--- a/ptn/missionalertbot/botcommands/StockTracker.py
+++ b/ptn/missionalertbot/botcommands/StockTracker.py
@@ -1,0 +1,201 @@
+"""
+Commands relating to carrier stock tracking.
+
+Dependencies: Constants, Database, Helpers, StockHelpers, ErrorHandler
+
+Stock tracker original code by DudeInCorner and Durzo
+"""
+
+# libraries
+import asyncio
+import json
+import re
+import requests
+from texttable import Texttable # TODO: remove this dependency
+import traceback
+
+# discord.py
+import discord
+from discord import app_commands
+from discord.app_commands import Group, command, describe
+from discord.ext import commands
+
+# local classes
+from ptn.missionalertbot.classes.MissionParams import MissionParams
+
+# local constants
+import ptn.missionalertbot.constants as constants
+from ptn.missionalertbot.constants import bot, certcarrier_role, trainee_role, rescarrier_role, mission_command_channel, training_mission_command_channel, \
+    bot_spam_channel, get_guild
+
+# local modules
+from ptn.missionalertbot.database.database import find_carrier, find_mission
+from ptn.missionalertbot.modules.helpers import check_roles, check_command_channel, flexible_carrier_search_term
+from ptn.missionalertbot.modules.StockHelpers import get_fc_stock
+from ptn.missionalertbot.modules.ErrorHandler import on_app_command_error, on_generic_error, CustomError, GenericError
+from ptn.missionalertbot.modules.MissionEditor import edit_discord_alerts
+
+
+# initialise the Cog and attach our global error handler
+class StockTracker(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    # custom global error handler
+    # attaching the handler when the cog is loaded
+    # and storing the old handler
+    def cog_load(self):
+        tree = self.bot.tree
+        self._old_tree_error = tree.on_error
+        tree.on_error = on_app_command_error
+
+    # detaching the handler when the cog is unloaded
+    def cog_unload(self):
+        tree = self.bot.tree
+        tree.on_error = self._old_tree_error
+
+
+    @app_commands.command(name='stock', description='Returns stock of a PTN carrier.')
+    @app_commands.describe(
+           carrier = "A unique fragment of the Fleet Carrier name you want to search for.",
+           source = "Choose data source between Frontier API or Inara. Defaults to Frontier API."
+        )
+    @app_commands.choices(source=[
+        discord.app_commands.Choice(name='Frontier API', value='capi'),
+        discord.app_commands.Choice(name='Inara', value='inara')
+        ])
+    async def stock(self, interaction: discord.Interaction, carrier: str = None, source: str = 'capi'):
+        carrier_string = f' for carrier {carrier}' if carrier else ''
+        source_string = f' from source {source}'
+        source_formal = 'Frontier API' if source == 'capi' else 'Inara.cz'
+        print(f"📈 Stock check called by {interaction.user} in {interaction.channel}" + carrier_string + source_string)
+
+        try:
+            embed = discord.Embed(
+                description="⏳ Please wait a moment...",
+                color=constants.EMBED_COLOUR_QU
+            )
+
+            await interaction.response.send_message(embed=embed)
+
+
+            # attempt to find matching carrier data
+            if not carrier:
+                # check if we're in a carrier's channel
+                carrier_data = find_carrier(interaction.channel.name, "discordchannel")
+
+                if not carrier_data:
+                    # no carrier data found, return a helpful error
+                    embed.description="❌ Please try again in a Trade Carrier's channel, or use the 'carrier' option to input the name of the carrier you wish to check the stock for."
+                    embed.color=constants.EMBED_COLOUR_ERROR
+
+                    return await interaction.edit_original_response(embed=embed)
+                
+            else:
+                # check for carriers by given search term
+                carrier_data = flexible_carrier_search_term(carrier)
+                
+                if not carrier_data:  # error condition
+                    print(f"❌ No carrier found matching search term {carrier}")
+                    carrier_error_embed = discord.Embed(
+                        description=f"❌ No carrier found for '**{carrier}**'. Use `/owner` to see a list of your carriers. If it's not in the list, ask an Admin to add it for you.",
+                        color=constants.EMBED_COLOUR_ERROR
+                    )
+                    return await interaction.edit_original_response(embed=carrier_error_embed)
+
+            # decide what to say about EDMC in the response footer
+            edmc_string = "Run EDMC for more accurate and up-to-date stock information."
+            mission_data = find_mission(carrier_data.carrier_long_name, "carrier")
+            if mission_data:
+                print(f"{carrier_data.carrier_long_name} is on a mission: {mission_data}")
+                mission_params: MissionParams = mission_data.mission_params
+                if mission_params.edmc_off:
+                    edmc_string = "⚠ Please keep EDMC disabled for this mission. ⚠"
+
+            # fetch stock levels
+            fcname = carrier_data.carrier_long_name
+
+            try:
+                stn_data = get_fc_stock(carrier_data.carrier_identifier, source)
+            except Exception as e:
+                try:
+                    error = f"Error getting data for carrier {carrier_data.carrier_identifier}: {e}"
+                    raise CustomError(error)
+                except Exception as e:
+                    await on_generic_error(interaction, e)
+                    traceback.print_exc()
+                    stn_data = False
+
+            if stn_data is False:
+                embed.description = f"📉 No market data for {carrier_data.carrier_long_name}."
+                embed.color=constants.EMBED_COLOUR_QU
+                embed.set_footer(text = f"Data source: {source_formal}" + (f"\n{edmc_string}" if source == 'inara' else ""))
+                await interaction.edit_original_response(embed=embed)
+                return
+
+            com_data = stn_data['commodities']
+            loc_data = stn_data['name']
+            if com_data == []:
+                embed.description = f"📉 No market data for {carrier_data.carrier_long_name}."
+                embed.color=constants.EMBED_COLOUR_QU
+                embed.set_footer(text = f"Data source: {source_formal}" + (f"\n{edmc_string}" if source == 'inara' else ""))
+                await interaction.edit_original_response(embed=embed)
+                return
+
+            table = Texttable()
+            table.set_cols_align(["l", "r", "r"])
+            table.set_cols_valign(["m", "m", "m"])
+            table.set_cols_dtype(['t', 'i', 'i'])
+            #table.set_deco(Texttable.HEADER | Texttable.HLINES)
+            table.set_deco(Texttable.HEADER)
+            table.header(["Commodity", "Amount", "Demand"])
+
+            for com in com_data:
+                if com['stock'] != 0 or com['demand'] != 0:
+                    table.add_row([com['name'], com['stock'], com['demand']])
+
+            msg = "```%s```\n" % ( table.draw() )
+
+            embed = discord.Embed()
+            embed.color = constants.EMBED_COLOUR_OK
+            embed.add_field(name = f"{fcname} ({stn_data['sName']}) stock", value = msg, inline = False)
+            embed.add_field(name = 'FC Location', value = loc_data, inline = False)
+            embed.set_footer(text = f"Data last updated: {stn_data['market_updated']}\nData source: {source_formal}\n" \
+                             + (f"\n{edmc_string}" if source == 'inara' else ""))
+
+            await interaction.edit_original_response(embed=embed)
+
+            # update mission alert if carrier was on a mission
+            if mission_data:
+                print("⌛ Evaluating stock for trade alert update...")
+                mission_params: MissionParams = mission_data.mission_params
+                # check if commodity from stock check matches from mission params
+                print("Checking for match for %s" % ( mission_params.commodity_name.title() ))
+
+                # create a list of commodities in stock - this is to handle future planned multi-commodity support
+                commodities_in_stock = []
+                for com in com_data:
+                    if com['name'].title() == mission_params.commodity_name.title():
+                        print("Found match: %s %s %s" % ( com['name'].title(), com['stock'], com['demand'] ))
+                        if com['stock'] != 0 or com['demand'] != 0:
+                            # retrieve correct value for supply or demand
+                            stock = com['stock'] if com['stock'] != 0 else com['demand']
+                        # create a DICT to hold the name/stock pair
+                        commodity = {'name': com['name'].title(), 'stock': stock}
+                        # add DICT to our list
+                        commodities_in_stock.append(commodity)
+
+                if commodities_in_stock:
+                    for commodity in commodities_in_stock:
+                        print("Found matching commodity %s at %s" % ( commodity['name'], commodity['stock'] ))
+
+                    spamchannel = bot.get_channel(bot_spam_channel())
+
+                    await edit_discord_alerts(interaction, mission_params, spamchannel, commodities_in_stock)
+
+        except Exception as e:
+            try:
+                raise GenericError(e)
+            except Exception as e:
+                traceback.print_exc()
+                await on_generic_error(interaction, e)

--- a/ptn/missionalertbot/classes/ChannelDefs.py
+++ b/ptn/missionalertbot/classes/ChannelDefs.py
@@ -1,0 +1,12 @@
+# a class to hold channel definitions for training mode
+class ChannelDefs:
+    def __init__(self, category_actual, alerts_channel_actual, mission_command_channel_actual, upvotes_channel_actual, wine_loading_channel_actual, wine_unloading_channel_actual, sub_reddit_actual, reddit_flair_in_progress, reddit_flair_completed):
+        self.category_actual = category_actual
+        self.alerts_channel_actual = alerts_channel_actual
+        self.mission_command_channel_actual = mission_command_channel_actual
+        self.upvotes_channel_actual = upvotes_channel_actual
+        self.wine_loading_channel_actual = wine_loading_channel_actual
+        self.wine_unloading_channel_actual = wine_unloading_channel_actual
+        self.sub_reddit_actual = sub_reddit_actual
+        self.reddit_flair_in_progress = reddit_flair_in_progress
+        self.reddit_flair_completed = reddit_flair_completed

--- a/ptn/missionalertbot/classes/MissionParams.py
+++ b/ptn/missionalertbot/classes/MissionParams.py
@@ -1,4 +1,6 @@
 from ptn.missionalertbot.classes.CarrierData import CarrierData
+from ptn.missionalertbot.classes.ChannelDefs import ChannelDefs
+from ptn.missionalertbot._metadata import __version__
 
 class MissionParams:
     """
@@ -20,9 +22,12 @@ class MissionParams:
         else:
             info_dict = dict()
 
+        self.mission_version = info_dict.get('mission_version', __version__) # the version of MAB the mission was generated under
         self.returnflag: bool = info_dict.get('returnflag', True) # used in various places during mission gen to indicate an error if false
         self.training: bool = info_dict.get('training', False) # whether this is a training mission or not
-        self.channel_defs = info_dict.get('channel_defs', None) # defines channels used by mission generator
+        self.channel_defs: ChannelDefs = info_dict.get('channel_defs', None) # defines channels used by mission generator
+        self.channel_alerts_actual: int = info_dict.get('channel_alerts_actual', None) # ID of alerts channel used when sending mission, as defined from ChannelDefs
+        self.role_ping_actual: int = info_dict.get('channel_alerts_actual', None) # ID of role ping used by bot when sending mission
         self.copypaste_embed = info_dict.get('copypaste_embed', None) # embed containing the copy/paste string for the command used
         self.carrier_name_search_term: str = info_dict.get('carrier_name_search_term', None) # the carrier name fragment to search for
         self.commodity_search_term: str = info_dict.get('commodity_search_term', None) # the commodity name fragment to search for
@@ -65,9 +70,12 @@ class MissionParams:
 
     def print_values(self):
         try:
+            print(f"version: {self.version}")
             print(f"returnflag: {self.returnflag}")
             print(f"training: {self.training}")
             print(f"channel_defs: {self.channel_defs}")
+            print(f"channel_alerts_actual: {self.channel_alerts_actual}")
+            print(f"role_ping_actual: {self.role_ping_actual}")
             print(f"copypaste_embed: {self.copypaste_embed}")
             print(f"carrier_name_search_term: {self.carrier_name_search_term}")
             print(f"commodity_search_term: {self.commodity_search_term}")
@@ -125,9 +133,12 @@ class MissionParams:
         """
         return (
             "⏩ Mission Params:\n"
+            f"version: {self.version}\n"
             f"returnflag: {self.returnflag}\n"
             f"training: {self.training}\n"
             f"channel_defs: {self.channel_defs}\n"
+            f"channel_alerts_actual: {self.channel_alerts_actual}\n"
+            f"role_ping_actual: {self.role_ping_actual}\n"
             f"copypaste_embed: {self.copypaste_embed}\n"
             f"carrier_name_search_term: {self.carrier_name_search_term}\n"
             f"commodity_search_term: {self.commodity_search_term}\n"

--- a/ptn/missionalertbot/classes/Views.py
+++ b/ptn/missionalertbot/classes/Views.py
@@ -988,6 +988,20 @@ class ConfirmPurgeView(View):
         await interaction.response.edit_message(embed=embed, view=None)
 
 
+    async def interaction_check(self, interaction: discord.Interaction): # only allow original command user to interact with buttons
+        if interaction.user.id == self.author.id:
+            return True
+        else:
+            embed = discord.Embed(
+                description="Only the command author may use these interactions.",
+                color=constants.EMBED_COLOUR_ERROR
+            )
+            embed.set_image(url='https://media1.tenor.com/images/939e397bf929b9768b24a8fa165301fe/tenor.gif?itemid=26077542')
+            embed.set_footer(text="Seriously, are you 4? 🙄")
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+            return False
+
+
     async def on_timeout(self): 
         # remove buttons
         self.clear_items()

--- a/ptn/missionalertbot/classes/Views.py
+++ b/ptn/missionalertbot/classes/Views.py
@@ -887,8 +887,6 @@ class AddCarrierButtons(View):
                 color=constants.EMBED_COLOUR_OK
             )
 
-            embed.set_footer(text=f"Called by {interaction.user.display_name} for {interaction.message.author.display_name}")
-
             await interaction.edit_original_response(embed=embed)
 
         except Exception as e:

--- a/ptn/missionalertbot/classes/Views.py
+++ b/ptn/missionalertbot/classes/Views.py
@@ -10,6 +10,7 @@ import asyncio
 import os
 from datetime import datetime
 import traceback
+import typing
 
 # import discord.py
 import discord
@@ -753,7 +754,7 @@ class SendNoticeModal(Modal):
 
 # Buttons for Add Carrier interaction
 class AddCarrierButtons(View):
-    def __init__(self, message, carrier_details, author):
+    def __init__(self, message, carrier_details, author: typing.Union[discord.Member, discord.User]):
         self.message: discord.Message = message
         self.carrier_details: dict = carrier_details
         self.author = author

--- a/ptn/missionalertbot/classes/Views.py
+++ b/ptn/missionalertbot/classes/Views.py
@@ -27,13 +27,14 @@ from ptn.missionalertbot.classes.CommunityCarrierData import CommunityCarrierDat
 
 # import local modules
 from ptn.missionalertbot.database.database import delete_nominee_from_db, delete_carrier_from_db, _update_carrier_details_in_database, find_carrier, CarrierDbFields, \
-    mission_db, missions_conn, add_carrier_to_database
-from ptn.missionalertbot.modules.DateString import get_mission_delete_hammertime
+    mission_db, missions_conn, add_carrier_to_database, carrier_db, _update_carrier_capi
+from ptn.missionalertbot.modules.DateString import get_mission_delete_hammertime, get_formatted_date_string
 from ptn.missionalertbot.modules.Embeds import _configure_all_carrier_detail_embed, _generate_cc_notice_embed, role_removed_embed, role_granted_embed, cc_renamed_embed, \
     _add_common_embed_fields, orphaned_carrier_summary_embed
 from ptn.missionalertbot.modules.ErrorHandler import GenericError, on_generic_error, CustomError, AsyncioTimeoutError
 from ptn.missionalertbot.modules.helpers import _remove_cc_manager
 from ptn.missionalertbot.modules.MissionCleaner import _cleanup_completed_mission
+from ptn.missionalertbot.modules.StockHelpers import capi
 
 
 # buttons for confirm role add
@@ -95,8 +96,8 @@ class ConfirmGrantRoleView(View):
         if not self.embeds:
         # return a message to the user that the interaction has timed out
             timeout_embed = discord.Embed(
-                description="Timed out.",
-                color=constants.EMBED_COLOUR_ERROR
+                description=":timer: Timed out.",
+                color=constants.EMBED_COLOUR_EXPIRED
             )
             self.embeds = [timeout_embed]
 
@@ -152,8 +153,8 @@ class ConfirmRemoveRoleView(View):
 
         # return a message to the user that the interaction has timed out
         timeout_embed = discord.Embed(
-            description="Timed out.",
-            color=constants.EMBED_COLOUR_ERROR
+            description=":timer: Timed out.",
+            color=constants.EMBED_COLOUR_EXPIRED
         )
 
         try:
@@ -261,8 +262,8 @@ class ConfirmRenameCC(View):
 
         # return a message to the user that the interaction has timed out
         timeout_embed = discord.Embed(
-            description="Timed out.",
-            color=constants.EMBED_COLOUR_ERROR
+            description=":timer: Timed out.",
+            color=constants.EMBED_COLOUR_EXPIRED
         )
 
         try:
@@ -337,8 +338,8 @@ class MissionDeleteView(View):
     async def on_timeout(self):
         # return a message to the user that the interaction has timed out
         timeout_embed = discord.Embed(
-            description="Timed out.",
-            color=constants.EMBED_COLOUR_ERROR
+            description=":timer: Timed out.",
+            color=constants.EMBED_COLOUR_EXPIRED
         )
 
         # remove buttons
@@ -836,23 +837,9 @@ class AddCarrierButtons(View):
                                         color=constants.EMBED_COLOUR_OK)
                     info_embed = _add_common_embed_fields(info_embed, carrier_data, interaction)
 
-                    cp_embed = discord.Embed(
-                        title="Copy/Paste code for Stockbot",
-                        description=f"▶ <#{bot_command_channel()}>:\n```;add_FC {carrier_data.carrier_identifier} {carrier_data.carrier_short_name} {carrier_data.ownerid}```",
-                        color=constants.EMBED_COLOUR_QU
-                    )
-
-                    embeds = [info_embed, cp_embed]
-
                     # TODO link with existing add_carrier function to remove duplicate code
 
-                    confirmation: discord.Message = await interaction.followup.send(embeds=embeds)
-
-                    stock_command_channel = bot.get_channel(bot_command_channel())
-
-                    content = f"<@{interaction.user.id}>: Please use the following command to add **{long_name}** ({carrier_id}) from {confirmation.jump_url} to Stockbot."
-
-                    await stock_command_channel.send(content=content, embed=cp_embed)
+                    confirmation: discord.Message = await interaction.followup.send(embed=info_embed)
 
                     # notify bot-spam
                     print("Notify bot-spam")
@@ -920,7 +907,8 @@ class AddCarrierButtons(View):
 
         if '🔎' in embed.title:
             # return a message to the user that the interaction has timed out
-            embed.set_footer(text="⏲ Timed out.")
+            embed.set_footer(text=":timer: Timed out.")
+            embed.color = constants.EMBED_COLOUR_EXPIRED
 
             try:
                 await self.message.edit(embed=embed, view=self)
@@ -1013,9 +1001,10 @@ class ConfirmPurgeView(View):
 
         embed: discord.Embed = message.embeds[0]
 
-        if embed.footer is not None:
+        if not embed.footer:
             # return a message to the user that the interaction has timed out
-            embed.set_footer(text="⏲ Timed out.")
+            embed.set_footer(text=":timer: Timed out.")
+            embed.color = constants.EMBED_COLOUR_EXPIRED
 
             try:
                 await self.message.edit(embed=embed, view=self)
@@ -1080,3 +1069,125 @@ class PurgeExcludeModal(Modal):
                 raise GenericError(e)
             except Exception as e:
                 await on_generic_error(interaction, e)
+
+
+# buttons for capi sync command
+class ConfirmCAPISync(View):
+    def __init__(self, original_embed: discord.Embed, author: typing.Union[discord.Member, discord.User]):
+        self.original_embed = original_embed
+        self.author = author
+        self.spamchannel = bot.get_channel(bot_spam_channel())
+        super().__init__(timeout=60)
+
+
+    @discord.ui.button(label='✗ Cancel', style=discord.ButtonStyle.danger, custom_id='capi_sync_cancel')
+    async def capi_sync_cancel(self, interaction: discord.Interaction, button):
+        print("User clicked cancel.")
+
+        self.original_embed.description="❌ Cancelled."
+        self.original_embed.color=constants.EMBED_COLOUR_OK
+
+        await interaction.response.edit_message(embed=self.original_embed, view=None)
+
+
+    @discord.ui.button(label='✔ Confirm', style=discord.ButtonStyle.primary, custom_id='capi_sync_confirm')
+    async def capi_sync_confirm(self, interaction: discord.Interaction, button):
+        print("User clicked confirm.")
+
+        posix_time_start = get_formatted_date_string()[2]
+        print(f"⏱ Start time: {posix_time_start}")
+
+        embed = discord.Embed(
+            description="⏳ Proceeding...",
+            color=constants.EMBED_COLOUR_QU
+        )
+
+        await interaction.response.edit_message(embed=embed, view=None)
+
+        # check fleet carrier capi status
+        carrier_db.execute(f"SELECT * FROM carriers")
+        carriers = [CarrierData(carrier) for carrier in carrier_db.fetchall()]
+
+        carrier: CarrierData
+
+        count = 0
+
+        updated_carriers = []
+
+        for carrier in carriers:
+            if not carrier.capi: # don't need to sync those already enabled
+                print("⏩ Processing %s (%s)" % ( carrier.carrier_long_name, carrier.carrier_identifier ))
+                capi_response = capi(carrier.carrier_identifier) # query CAPI
+                print(f"capi response: {capi_response.status_code}")
+                if capi_response.status_code == 200: # positive response, update the carrier db
+                    await _update_carrier_capi(carrier.pid, 1)
+                    count += 1 # tally our totals
+                    # generate a summary of carriers updated
+                    updated_carriers.append(carrier.carrier_long_name)
+    
+        posix_time_complete = get_formatted_date_string()[2]
+        print(f"✅ Complete time: {posix_time_start}")
+
+        total_time = int(posix_time_complete - posix_time_start)
+        print(f"⏱ Total time: {total_time} seconds")
+
+        # generate an embed summary
+        updated_carriers_string = ", ".join(updated_carriers)
+        embed = discord.Embed(
+            title="✅ CAPI SYNC COMPLETE",
+            description=f"Updated {count} carriers in {total_time} seconds:\n\n"
+                        f"{updated_carriers_string}",
+            color=constants.EMBED_COLOUR_OK
+        )
+
+        await interaction.edit_original_response(embed=embed, view=None)
+
+        spamchannel_embed = discord.Embed(
+            description=f"🤖 <@{interaction.user.id}> used `/admin sync_capi` in {interaction.message.jump_url} to update CAPI flag for {count} carriers.",
+            color=constants.EMBED_COLOUR_QU
+        )
+
+        await self.spamchannel.send(embed=spamchannel_embed)
+
+
+    async def interaction_check(self, interaction: discord.Interaction): # only allow original command user to interact with buttons
+        if interaction.user.id == self.author.id:
+            return True
+        else:
+            embed = discord.Embed(
+                description="Only the command author may use these interactions.",
+                color=constants.EMBED_COLOUR_ERROR
+            )
+            embed.set_image(url='https://media1.tenor.com/images/939e397bf929b9768b24a8fa165301fe/tenor.gif?itemid=26077542')
+            embed.set_footer(text="Seriously, are you 4? 🙄")
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+            return False
+
+
+    async def on_timeout(self):
+        try:
+            # remove buttons
+            self.clear_items()
+            print("View timed out")
+
+            self.message: discord.Message
+
+            message = await self.message.channel.fetch_message(self.message.id)
+
+            embed: discord.Embed = message.embeds[0]
+
+            if not embed.title:
+                # return a message to the user that the interaction has timed out
+                embed.description=(":timer: Timed out.")
+                embed.color=constants.EMBED_COLOUR_EXPIRED
+
+                try:
+                    await self.message.edit(embed=embed, view=self)
+                except Exception as e:
+                    print(f'Failed applying timeout: {e}')
+
+            else:
+                await self.message.edit(view=None)
+        except Exception as e:
+            print(e)
+            traceback.print_exc()

--- a/ptn/missionalertbot/classes/WMMData.py
+++ b/ptn/missionalertbot/classes/WMMData.py
@@ -1,8 +1,8 @@
-class CarrierData:
+class WMMData:
 
     def __init__(self, info_dict=None):
         """
-        Class represents a carrier object as returned from the database.
+        Class represents a WMM tracking object as returned from the database.
 
         :param sqlite.Row info_dict: A single row from the sqlite query.
         """
@@ -12,19 +12,17 @@ class CarrierData:
         else:
             info_dict = dict()
 
-        self.carrier_long_name = info_dict.get('longname', None)
-        self.carrier_short_name = info_dict.get('shortname', None)
+        self.carrier_name = info_dict.get('carrier', None)
         self.carrier_identifier = info_dict.get('cid', None)
-        self.discord_channel = info_dict.get('discordchannel', None)
-        self.channel_id = info_dict.get('channelid', None)
-        self.ownerid = info_dict.get('ownerid', None)
-        self.lasttrade = info_dict.get('lasttrade', None)
-        self.pid = info_dict.get('p_ID', None)
+        self.carrier_location = info_dict.get('location', None)
+        self.carrier_owner = info_dict.get('ownerid', None)
+        self.notification_status = info_dict.get('notify', None)
         self.capi = info_dict.get('capi', None)
+
 
     def to_dictionary(self):
         """
-        Formats the carrier data into a dictionary for easy access.
+        Formats the data into a dictionary for easy access.
 
         :returns: A dictionary representation for the carrier data.
         :rtype: dict
@@ -41,10 +39,9 @@ class CarrierData:
 
         :rtype: str
         """
-        return 'CarrierData: CarrierLongName:{0.carrier_long_name} CarrierShortName:{0.carrier_short_name} ' \
-               'CarrierIdentifier:{0.carrier_identifier} DiscordChannel:{0.discord_channel} ' \
-               'DiscordChannelID:{0.channel_id} OwnerID:{0.ownerid} CarrierPid:{0.pid} ' \
-               'LastTrade:{0.lasttrade} cAPI: {0.capi} '.format(self)
+        return 'WMMData: CarrierLongName:{0.carrier_name} CarrierIdentifier:{0.carrier_identifier} ' \
+               'CarrierLocation:{0.carrier_location} NotificationStatus:{0.notification_status} ' \
+               'Owner: {0.carrier_owner} CAPI:{0.capi}'.format(self)
 
     def __bool__(self):
         """

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -322,7 +322,7 @@ DISCORD_INVITE_URL = 'https://discord.gg/ptn'
 
 # link to our Discord by way of Josh's original post on Reddit
 REDDIT_DISCORD_LINK_URL = \
-    'https://www.reddit.com/r/PilotsTradeNetwork/comments/l0y7dk/pilots_trade_network_intergalactic_discord_server/'
+    'https://discord.gg/ptn'
 
 
 # define constants based on prod or test environment

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -104,6 +104,7 @@ PROD_PILOT_ROLE = 800396412217982999 # Pilot role
 PROD_EVENT_ORGANISER_ROLE = 1023296182639939594 # Event Organiser
 PROD_BOT_ROLE = 802523214809923596 # General Bot role on live (Robot Overlords)
 PROD_ALUM_ROLE = 1086777372981858404 # Council Alumni role on live
+PROD_CCO_COLOR_ROLE = 1166838944109957240 # CCO Color role on live
 PROD_TRADE_CAT = 801558838414409738 # Trade Carrier category on live server
 PROD_ARCHIVE_CAT = 1048957416781393970 # Archive category on live server
 PROD_SECONDS_VERY_SHORT = 10 # time between channel deletion trigger and actual deletion (10)
@@ -165,6 +166,7 @@ TEST_PILOT_ROLE = 818174614810787840 # Pilot role
 TEST_EVENT_ORGANISER_ROLE = 1121748430650355822 # Event Organiser
 TEST_BOT_ROLE = 842524877051133963 # TestingAlertBot role only - need a generic bot role on test
 TEST_ALUM_ROLE = 1156729563188035664 # Alumni role on test server
+TEST_CCO_COLOR_ROLE = 1168280960572334151 # CCO Color role on test server
 TEST_TRADE_CAT = 876569219259580436 # Trade Carrier category on live server
 TEST_ARCHIVE_CAT = 877244591579992144 # Archive category on live server
 TEST_SECONDS_VERY_SHORT = 10 # time between channel deletion trigger and actual deletion
@@ -454,6 +456,9 @@ def bot_role():
 
 def alum_role():
     return PROD_ALUM_ROLE if _production else TEST_ALUM_ROLE
+
+def cco_color_role():
+    return PROD_CCO_COLOR_ROLE if _production else TEST_CCO_COLOR_ROLE
 
 def trade_cat():
   return PROD_TRADE_CAT if _production else TEST_TRADE_CAT

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -78,6 +78,8 @@ PROD_DEV_CHANNEL = 827656814911815702 # Development channel for MAB on live
 PROD_ROLEAPPS_CHANNEL = 867820665515147293 # role-applications on the live server
 PROD_UPVOTE_EMOJI = 828287733227192403 # upvote emoji on live server
 PROD_O7_EMOJI = 806138784294371368 # o7 emoji on live server
+PROD_UNLOADING_ICON = 1160881163641049178 # unloading_icon on live
+PROD_LOADING_ICON = 1160871046786846780 # loading_icon on live
 PROD_FC_COMPLETE_EMOJI = 878216234653605968 # fc_complete emoji
 PROD_FC_EMPTY_EMOJI = 878216288525242388 # fc_empty emoji
 PROD_DISCORD_EMOJI = 1122605426844905503 # Discord emoji on live
@@ -137,6 +139,8 @@ TEST_DEV_CHANNEL = 1063765215457583164 # Development channel for MAB on test
 TEST_ROLEAPPS_CHANNEL = 1121736676247609394 # role-applications on the test server
 TEST_UPVOTE_EMOJI = 849388681382068225 # upvote emoji on test server
 TEST_O7_EMOJI = 903744117144698950 # o7 emoji on test server
+TEST_UNLOADING_ICON = 1160883198419542077 # unloading_icon on test
+TEST_LOADING_ICON = 1160883199833014362 # loading_icon on test
 TEST_FC_COMPLETE_EMOJI = 884673510067286076 # fc_complete emoji
 TEST_FC_EMPTY_EMOJI = 974747678183424050 # fc_empty emoji
 TEST_DISCORD_EMOJI = 1122605718198026300 # Discord emoji on live
@@ -293,15 +297,17 @@ OPT_IN_ID = 'OPT-INX'
 
 # images and icons used in mission embeds
 BLANKLINE_400PX = 'https://pilotstradenetwork.com/wp-content/uploads/2023/01/400x1-00000000.png'
-ICON_BUY = 'https://pilotstradenetwork.com/wp-content/uploads/2023/05/Trade.png'
-ICON_SELL = 'https://pilotstradenetwork.com/wp-content/uploads/2023/06/Credit.png'
+ICON_BUY_FROM_STATION = 'https://pilotstradenetwork.com/wp-content/uploads/2023/10/mab_buy_from_station.png'
+ICON_BUY_FROM_CARRIER = 'https://pilotstradenetwork.com/wp-content/uploads/2023/10/mab_buy_from_carrier.png'
+ICON_SELL_TO_STATION = 'https://pilotstradenetwork.com/wp-content/uploads/2023/10/mab_sell_to_station.png'
+ICON_SELL_TO_CARRIER = 'https://pilotstradenetwork.com/wp-content/uploads/2023/10/mab_sell_to_carrier.png'
 ICON_DATA = 'https://pilotstradenetwork.com/wp-content/uploads/2023/06/Data.png'
 ICON_DISCORD_CIRCLE = 'https://pilotstradenetwork.com/wp-content/uploads/2023/06/discord-icon-in-circle.png'
 ICON_DISCORD_PING = 'https://pilotstradenetwork.com/wp-content/uploads/2023/06/discord-notification-dot-icon.png'
 ICON_REDDIT = 'https://pilotstradenetwork.com/wp-content/uploads/2023/06/reddit-logo.png'
 ICON_WEBHOOK_PTN = 'https://pilotstradenetwork.com/wp-content/uploads/2023/06/discord-webhook-icon-in-circle.png'
-ICON_FC_LOADING = 'https://pilotstradenetwork.com/wp-content/uploads/2023/06/fc_loading_thick_sihmm.png'
-ICON_FC_UNLOADING = 'https://pilotstradenetwork.com/wp-content/uploads/2023/06/fc_unloading_thick_sihmm.png'
+ICON_LOADING = 'https://pilotstradenetwork.com/wp-content/uploads/2023/10/sim_loading_graphic_mab.png'
+ICON_UNLOADING = 'https://pilotstradenetwork.com/wp-content/uploads/2023/10/sim_unloading_graphic_mab.png'
 ICON_EDMC_OFF = 'https://pilotstradenetwork.com/wp-content/uploads/2023/06/edmc_off_2.jpg'
 ICON_FC_COMPLETE = 'https://pilotstradenetwork.com/wp-content/uploads/2023/05/fc_complete.png'
 ICON_FC_EMPTY = 'https://pilotstradenetwork.com/wp-content/uploads/2023/06/fc_empty.png'
@@ -370,6 +376,12 @@ def upvote_emoji():
 
 def o7_emoji():
   return PROD_O7_EMOJI if _production else TEST_O7_EMOJI
+
+def loading_emoji():
+  return PROD_LOADING_ICON if _production else TEST_LOADING_ICON
+
+def unloading_emoji():
+  return PROD_UNLOADING_ICON if _production else TEST_LOADING_ICON
 
 def fc_complete_emoji():
   return PROD_FC_COMPLETE_EMOJI if _production else TEST_FC_COMPLETE_EMOJI

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -98,6 +98,7 @@ PROD_DEV_ROLE = 812988180210909214 # Developer role ID on live
 PROD_MOD_ROLE = 813814494563401780 # Mod role ID on Live
 PROD_SOMM_ROLE = 838520893181263872 # Sommelier role ID on live
 PROD_VERIFIED_ROLE = 867820916331118622 # Verified Member
+PROD_PILOT_ROLE = 800396412217982999 # Pilot role
 PROD_EVENT_ORGANISER_ROLE = 1023296182639939594 # Event Organiser
 PROD_BOT_ROLE = 802523214809923596 # General Bot role on live (Robot Overlords)
 PROD_ALUM_ROLE = 1086777372981858404 # Council Alumni role on live
@@ -156,6 +157,7 @@ TEST_RECRUIT_ROLE = 1121916871088803871 # CCO Recruit role
 TEST_CPILLAR_ROLE = 903289927184314388 # Community Pillar role on test server
 TEST_DEV_ROLE = 1048913812163678278 # Dev role ID on test
 TEST_VERIFIED_ROLE = 903289848427851847 # Verified Member
+TEST_PILOT_ROLE = 818174614810787840 # Pilot role
 TEST_EVENT_ORGANISER_ROLE = 1121748430650355822 # Event Organiser
 TEST_BOT_ROLE = 842524877051133963 # TestingAlertBot role only - need a generic bot role on test
 TEST_ALUM_ROLE = 1156729563188035664 # Alumni role on test server
@@ -428,6 +430,9 @@ def dev_role():
 
 def verified_role():
   return PROD_VERIFIED_ROLE if _production else TEST_VERIFIED_ROLE
+
+def pilot_role():
+  return PROD_PILOT_ROLE if _production else TEST_PILOT_ROLE
 
 def event_organiser_role():
   return PROD_EVENT_ORGANISER_ROLE if _production else TEST_EVENT_ORGANISER_ROLE

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -96,6 +96,7 @@ PROD_RECRUIT_ROLE = 800681823575343116 # CCO Recruit role
 PROD_CPILLAR_ROLE = 863789660425027624 # Community Pillar role on live server
 PROD_DEV_ROLE = 812988180210909214 # Developer role ID on live
 PROD_MOD_ROLE = 813814494563401780 # Mod role ID on Live
+PROD_SOMM_ROLE = 838520893181263872 # Sommelier role ID on live
 PROD_VERIFIED_ROLE = 867820916331118622 # Verified Member
 PROD_EVENT_ORGANISER_ROLE = 1023296182639939594 # Event Organiser
 PROD_BOT_ROLE = 802523214809923596 # General Bot role on live (Robot Overlords)
@@ -144,6 +145,7 @@ TEST_CC_ROLE = 877220476827619399 # CC role on test server
 TEST_CC_CAT = 877108931699310592 # Community Carrier category on test server
 TEST_ADMIN_ROLE = 836367194979041351 # Bot Admin role on test server
 TEST_MOD_ROLE = 903292469049974845 # Mod role on test server
+TEST_SOMM_ROLE = 849907019502059530 # Sommeliers on test server
 TEST_CMENTOR_ROLE = 877586763672072193 # Community Mentor role on test server
 TEST_CERTCARRIER_ROLE = 822999970012463154 # Certified Carrier role on test server
 TEST_RESCARRIER_ROLE = 947520552766152744 # Fleet Reserve Carrier role on test server
@@ -393,6 +395,9 @@ def admin_role():
 
 def mod_role():
   return PROD_MOD_ROLE if _production else TEST_MOD_ROLE
+
+def somm_role():
+  return PROD_SOMM_ROLE if _production else TEST_SOMM_ROLE
 
 def cmentor_role():
   return PROD_CMENTOR_ROLE if _production else TEST_CMENTOR_ROLE

--- a/ptn/missionalertbot/constants.py
+++ b/ptn/missionalertbot/constants.py
@@ -181,6 +181,7 @@ EMBED_COLOUR_RP = 0xe63946              # PTN red
 EMBED_COLOUR_ERROR = 0x800000           # dark red
 EMBED_COLOUR_QU = 0x00d9ff              # que?
 EMBED_COLOUR_OK = 0x80ff80              # we're good here thanks, how are you?
+EMBED_COLOUR_WARNING = 0xFFD700         # and it was all yellow
 
 
 # defining fonts for pillow use

--- a/ptn/missionalertbot/database/database.py
+++ b/ptn/missionalertbot/database/database.py
@@ -20,6 +20,7 @@ from datetime import timezone
 from ptn.missionalertbot.classes.CarrierData import CarrierData
 from ptn.missionalertbot.classes.Commodity import Commodity
 from ptn.missionalertbot.classes.MissionData import MissionData
+from ptn.missionalertbot.classes.MissionParams import MissionParams
 from ptn.missionalertbot.classes.CommunityCarrierData import CommunityCarrierData
 from ptn.missionalertbot.classes.NomineesData import NomineesData
 from ptn.missionalertbot.classes.WebhookData import WebhookData
@@ -32,6 +33,19 @@ from ptn.missionalertbot.database.Commodities import commodities_all
 # local modules
 from ptn.missionalertbot.modules.DateString import get_formatted_date_string
 from ptn.missionalertbot.modules.ErrorHandler import CustomError, on_generic_error
+
+
+# ensure all paths function for a clean install
+def build_directory_structure_on_startup():
+    print("Building directory structure...")
+    os.makedirs(constants.DB_PATH, exist_ok=True) # /database - the main database files
+    os.makedirs(constants.IMAGE_PATH, exist_ok=True) # /images - carrier images
+    os.makedirs(f"{constants.IMAGE_PATH}/old", exist_ok=True) # /images/old - backed up carrier images
+    os.makedirs(constants.SQL_PATH, exist_ok=True) # /database/db_sql - DB SQL dumps
+    os.makedirs(constants.BACKUP_DB_PATH, exist_ok=True) # /database/backups - db backups
+    os.makedirs(constants.CC_IMAGE_PATH, exist_ok=True) # /images/cc - CC thumbnail images
+
+build_directory_structure_on_startup() # build directory structure when bot first starts
 
 
 # connect to sqlite carrier database
@@ -284,17 +298,6 @@ def create_missing_column(table, column, existing, db_name, db_obj, db_conn, cre
     print('Operation complete.')
     db_conn.commit()
     return
-
-
-# ensure all paths function for a clean install
-def build_directory_structure_on_startup():
-    print("Building directory structure...")
-    os.makedirs(constants.DB_PATH, exist_ok=True) # /database - the main database files
-    os.makedirs(constants.IMAGE_PATH, exist_ok=True) # /images - carrier images
-    os.makedirs(f"{constants.IMAGE_PATH}/old", exist_ok=True) # /images/old - backed up carrier images
-    os.makedirs(constants.SQL_PATH, exist_ok=True) # /database/db_sql - DB SQL dumps
-    os.makedirs(constants.BACKUP_DB_PATH, exist_ok=True) # /database/backups - db backups
-    os.makedirs(constants.CC_IMAGE_PATH, exist_ok=True) # /images/cc - CC thumbnail images
 
 
 # build the databases, from scratch if needed
@@ -748,7 +751,7 @@ def find_mission(searchterm, searchfield):
     # unpickle the mission_params object if it exists
     if mission_data.mission_params:
         print("Found mission_params, enumerating...")
-        mission_data.mission_params = pickle.loads(mission_data.mission_params)
+        mission_data.mission_params: MissionParams = pickle.loads(mission_data.mission_params)
         mission_data.mission_params.print_values()
     else:
         print("No mission_params found")

--- a/ptn/missionalertbot/database/database.py
+++ b/ptn/missionalertbot/database/database.py
@@ -745,8 +745,16 @@ def find_mission(searchterm, searchfield):
     """
     mission_db.execute(f'''SELECT * FROM missions WHERE {searchfield} LIKE (?)''',
                         (f'%{searchterm}%',))
-    mission_data = MissionData(mission_db.fetchone())
-    print(f'Found mission data: {mission_data}')
+    row = MissionData(mission_db.fetchone())
+
+    # check whether a mission exists
+    if row is None:
+        print(f'No mission found for {searchterm} in {searchfield}')
+        mission_data = None
+        return mission_data
+    else:
+        mission_data = MissionData(mission_db.fetchone())
+        print(f'Found mission data: {mission_data}')
 
     # unpickle the mission_params object if it exists
     if mission_data.mission_params:
@@ -755,7 +763,6 @@ def find_mission(searchterm, searchfield):
         mission_data.mission_params.print_values()
     else:
         print("No mission_params found")
-        return mission_data
 
     return mission_data
 

--- a/ptn/missionalertbot/database/database.py
+++ b/ptn/missionalertbot/database/database.py
@@ -745,7 +745,7 @@ def find_mission(searchterm, searchfield):
     """
     mission_db.execute(f'''SELECT * FROM missions WHERE {searchfield} LIKE (?)''',
                         (f'%{searchterm}%',))
-    row = MissionData(mission_db.fetchone())
+    row = mission_db.fetchone()
 
     # check whether a mission exists
     if row is None:
@@ -753,7 +753,7 @@ def find_mission(searchterm, searchfield):
         mission_data = None
         return mission_data
     else:
-        mission_data = MissionData(mission_db.fetchone())
+        mission_data = MissionData(row)
         print(f'Found mission data: {mission_data}')
 
     # unpickle the mission_params object if it exists

--- a/ptn/missionalertbot/modules/BackgroundTasks.py
+++ b/ptn/missionalertbot/modules/BackgroundTasks.py
@@ -14,7 +14,7 @@ from ptn.missionalertbot.classes.MissionData import MissionData
 
 # import local constants
 import ptn.missionalertbot.constants as constants
-from ptn.missionalertbot.constants import get_reddit, reddit_channel, sub_reddit, bot_guild, certcarrier_role, rescarrier_role, bot_spam_channel
+from ptn.missionalertbot.constants import get_reddit, reddit_channel, sub_reddit, bot_guild, certcarrier_role, rescarrier_role, bot_spam_channel, cco_color_role
 
 # import local modules
 from ptn.missionalertbot.database.database import CarrierDbFields, carrier_db, mission_db, find_carrier, bot
@@ -90,6 +90,7 @@ async def lasttrade_cron():
         # get roles
         guild = bot.get_guild(bot_guild())
         cc_role = discord.utils.get(guild.roles, id=certcarrier_role())
+        cc_color_role = discord.utils.get(guild.roles, id=cco_color_role())
         fr_role = discord.utils.get(guild.roles, id=rescarrier_role())
         # get spam channel
         spamchannel = bot.get_channel(bot_spam_channel())
@@ -119,6 +120,9 @@ async def lasttrade_cron():
                     owner_dm = await bot.fetch_user(carrier_data.ownerid)
                     await owner_dm.send(f"Ahoy CMDR! Your last PTN Fleet Carrier trade was more than 28 days ago at {last_traded} so you have been automatically marked as inactive and placed in the PTN Fleet Reserve. You can visit <#939919613209223270> or use `/cco active` to **mark yourself as active and return to trading**. o7 CMDR!")
                     print(f"Notified {owner.name} by DM.")
+                if cc_color_role in owner.roles:
+                    print(f"{owner.name} has the CCO Color role, removing.")
+                    await owner.remove_roles(cc_color_role)
                 if fr_role not in owner.roles:
                     print(f"{owner.name} does not have the Fleet Reserve role, adding.")
                     await owner.add_roles(fr_role)

--- a/ptn/missionalertbot/modules/BackgroundTasks.py
+++ b/ptn/missionalertbot/modules/BackgroundTasks.py
@@ -3,23 +3,40 @@ BackgroundTasks.py
 
 """
 
+import sys
+
+if __name__ == "__main__":
+    # Prevent accidental independent execution of this file 
+    print("This script should not be run independently. Please run it through application.py.")
+    # Exit the script with an error code
+    sys.exit(1)
+
 # import libraries
-import discord
-from discord.ext import tasks
+import asyncio
 from datetime import datetime, timezone, timedelta
+import json
+import traceback
+
+# import discord
+import discord
+from discord import Forbidden
+from discord.ext import tasks
 
 # import local classes
 from ptn.missionalertbot.classes.CarrierData import CarrierData
 from ptn.missionalertbot.classes.MissionData import MissionData
+from ptn.missionalertbot.classes.WMMData import WMMData
 
 # import local constants
 import ptn.missionalertbot.constants as constants
-from ptn.missionalertbot.constants import get_reddit, reddit_channel, sub_reddit, bot_guild, certcarrier_role, rescarrier_role, bot_spam_channel, cco_color_role
+from ptn.missionalertbot.constants import get_reddit, reddit_channel, sub_reddit, bot_guild, certcarrier_role, rescarrier_role, \
+    bot_spam_channel, cco_color_role, commodities_wmm, channel_cco_wmm_supplies, channel_wmm_stock
 
 # import local modules
-from ptn.missionalertbot.database.database import CarrierDbFields, carrier_db, mission_db, find_carrier, bot
-
-
+from ptn.missionalertbot.database.database import CarrierDbFields, carrier_db, mission_db, find_carrier, bot, _fetch_wmm_carriers, \
+    _update_wmm_carrier, _update_carrier_capi
+from ptn.missionalertbot.modules.helpers import clear_history
+from ptn.missionalertbot.modules.StockHelpers import capi, get_fc_stock, chunk, notify_wmm_owner
 
 
 # monitor reddit comments
@@ -109,7 +126,7 @@ async def lasttrade_cron():
         for carrier_data in carriers:
             # check roles on owners, remove/add as needed.
             last_traded = datetime.fromtimestamp(carrier_data.lasttrade).strftime('%Y-%m-%d %H:%M:%S')
-            print(f"Processing carrier '{carrier_data.carrier_short_name}'. Last traded: {last_traded}")
+            print(f"Processing carrier '{carrier_data.carrier_long_name}'. Last traded: {last_traded}")
             owner = guild.get_member(carrier_data.ownerid)
             if owner:
                 if cc_role in owner.roles:
@@ -129,9 +146,299 @@ async def lasttrade_cron():
                     await spamchannel.send(f"{owner.name} has been added to the Fleet Reserve role.")
             else:
                 print(f"Carrier owner id {carrier_data.ownerid} is invalid, skipping.")
-                await spamchannel.send(f"Owner of {carrier_data.carrier_short_name} with ID {carrier_data.ownerid} is invalid. "
+                await spamchannel.send(f"Owner of {carrier_data.carrier_long_name} ({carrier_data.carrier_identifier}) with ID {carrier_data.ownerid} is invalid. "
                                         "Cannot process lasttrade_cron for this carrier.")
         print("All carriers have been processed.")
     except Exception as e:
         print(f"last trade cron failed: {e}")
         pass
+
+
+# function to start WMM loop
+async def start_wmm_task():
+    if wmm_stock.is_running():
+        print("def start_wmm_task: task is_running(), cannot start.")
+        return False
+    wmm_channel = bot.get_channel(channel_wmm_stock())
+    ccochannel = bot.get_channel(channel_cco_wmm_supplies())
+    print("Clearing last stock update message in #%s" % wmm_channel)
+    await clear_history(wmm_channel)
+    print("Starting WMM stock background task")
+    message = await wmm_channel.send('⌛ WMM stock tracking initialized, preparing for update.')
+    wmm_stock.start(message, wmm_channel, ccochannel)
+
+
+# WMM loop
+# TODO: introduce tracking of status and errors to bot-spam
+@tasks.loop(seconds=30)
+async def wmm_stock(message, wmm_channel, ccochannel):
+    print("▶ Starting WMM stock check loop.")
+
+    #print(f"wmm_stock function start")
+    wmm_systems = []
+
+    # retrieve all WMM carriers
+    wmm_carriers = _fetch_wmm_carriers()
+
+    carrier: WMMData
+
+    # populate active WMM systems
+    for carrier in wmm_carriers:
+        if carrier.carrier_location not in wmm_systems:
+            wmm_systems.append(carrier.carrier_location)
+
+    # Message to send to the WMM channel if no carriers are being tracked
+    # TODO: harmonise with MAB formats
+    if wmm_systems == []:
+        nofc = "WMM Stock: No Fleet Carriers are currently being tracked for WMM. Please add some to the list!"
+        try:
+            await message.edit(content=nofc)
+        except:
+            await clear_history(wmm_channel)
+            await wmm_channel.send(nofc)
+        return
+
+    content = {}
+    ccocontent = {}
+    wmm_stock = {}
+    wmm_station_stock = {}
+
+    for carrier in wmm_carriers:
+        print(f"Interrogating {carrier} for stock...")
+        carrier_has_stock = False
+        if carrier.capi:
+            print(f"Calling CAPI for {carrier.carrier_name}")
+            capi_response = capi(carrier.carrier_identifier)
+            stn_data = capi_response.json()
+
+            print(f"capi response: {capi_response.status_code}")
+            if capi_response.status_code != 200:
+                # TODO handle missing carriers, auth errors etc.
+                print(f"Error from CAPI for {carrier.carrier_identifier}: {capi_response.status_code} - {stn_data}")
+                if capi_response.status_code == 500:
+                    # this is an internal stockbot api error, dont re-auth for this.
+                    print(f"Internal stockbot API error, someone check the logs")
+                    continue
+                elif capi_response.status_code == 418:
+                    # capi is down for maintenance.
+                    await clear_history(wmm_channel)
+                    message = f"Bleep Bloop: Frontier API is down for maintenance, unable to retrieve stocks for all carriers. Retrying in 60 seconds."
+                    await wmm_channel.send(message)
+                    await asyncio.sleep(60)
+                    return
+                elif capi_response.status_code == 400 or capi_response.status_code == 401:
+                    print(f"cAPI auth failed for {carrier.carrier_name}")
+
+                    # User needs to re-auth. (400 = EGS, 401 = Expired Token)
+
+                    # remove CAPI flag from databases
+                    carrier.capi = 0
+                    await _update_wmm_carrier(carrier)
+                    await _update_carrier_capi(carrier.carrier_identifier, 0)
+
+                    embed = discord.Embed(
+                        description=f"<@{bot.user.id}> was unable to retrieve stock levels for {carrier.carrier_name} ({carrier.carrier_identifier}) from the Frontier API. "
+                                    "Please use `/cco capi enable` to re-enable authentication for this fleet carrier. Inara will be used to fetch stock levels until cAPI is re-enabled.",
+                        color = constants.EMBED_COLOUR_WARNING
+                    )
+
+                    message = f"<@{carrier.carrier_owner} Unable to send you a direct message relating to WMM tracking status. " \
+                              f"Your Frontier API authentication has expired for {carrier.carrier_name} ({carrier.carrier_identifier}). " \
+                              f"Please enable direct messages from <@{bot.user.id}> and use `/cco capi enable` to proceed."
+
+                    # notify the owner
+                    await notify_wmm_owner(carrier, embed, message)
+                    
+                else:
+                    # all other unknown errors.
+                    print(f"Unknown error from CAPI, see above for details.")
+                    continue
+            else:
+                carrier_name = f"**{carrier.carrier_name} ({carrier.carrier_identifier})**"
+                market_updated = ''
+
+        # this catches the case where we remove the cAPI flag above if auth fails.
+        if not carrier.capi:
+            stn_data = get_fc_stock(carrier.carrier_identifier, 'inara')
+            if not stn_data:
+                print(f"no inara market data for {carrier.carrier_identifier}")
+                continue
+            carrier_name = stn_data['full_name'].upper()
+            stn_data['currentStarSystem'] = stn_data['name'].title()
+            stn_data['market'] = {'commodities': stn_data['commodities']}
+            try:
+                utc_time = datetime.strptime(stn_data['market_updated'].split('(')[1][0:-1], "%d %b %Y, %I:%M%p")
+                market_updated = "(As of <t:%d:R>)" % utc_time.timestamp()
+            except:
+                market_updated = "(As of %s)" % stn_data['market_updated']
+                pass
+        if 'market' not in stn_data:
+            print(f"No market data for {carrier.carrier_identifier}")
+            continue
+
+        # now we interrogate the carrier's stock levels
+        com_data = stn_data['market']['commodities']
+        print("Market data for %s: %s" % ( carrier.carrier_name, com_data ))
+
+        # check for if market is empty
+        if com_data == []:
+            # TODO: how should this look?
+            content[carrier.carrier_location].append("**%s** - %s (%s) has no current market data. please visit the carrier with EDMC running" % (
+                carrier.carrier_name, stn_data['currentStarSystem'], carrier.carrier_location )
+            )
+            continue
+
+        # iterate through commodities
+        for com in com_data:
+            # add carrier location to the wmm_stock list if not already there
+            if carrier.carrier_location not in wmm_stock:
+                wmm_stock[carrier.carrier_location] = []
+            if stn_data['currentStarSystem'] not in wmm_station_stock:
+                wmm_station_stock[stn_data['currentStarSystem']] = {}
+            if carrier.carrier_location not in wmm_station_stock[stn_data['currentStarSystem']]:
+                wmm_station_stock[stn_data['currentStarSystem']][carrier.carrier_location] = {}
+
+            # add commodity to the master list if not already there
+            if com['name'].title() not in commodities_wmm:
+                continue
+
+            # if carrier has stock of the commodity
+            if com['stock'] != 0:
+                carrier_has_stock = True
+                if com['name'].lower() not in wmm_station_stock[stn_data['currentStarSystem']][carrier.carrier_location]:
+                    wmm_station_stock[stn_data['currentStarSystem']][carrier.carrier_location][com['name'].lower()] = int(com['stock'])
+                else:
+                    wmm_station_stock[stn_data['currentStarSystem']][carrier.carrier_location][com['name'].lower()] += int(com['stock'])
+
+                # if commodity stock is low 
+                if int(com['stock']) < 1000:
+                    wmm_stock[carrier.carrier_location].append("%s x %s - %s (%s) - **%s** - Price: %s - LOW STOCK %s" % (
+                        com['name'], format(com['stock'], ','), stn_data['currentStarSystem'], carrier.carrier_location, carrier_name, format(com['buyPrice'], ','), market_updated )
+                    )
+
+                    # Notify the owner once per commodity per wmm_tracking session.
+                    notification_status = json.loads(carrier.notification_status) if carrier.notification_status else []
+                    if com['name'] not in notification_status:
+                        print(f"Generating low stock warning for {carrier.carrier_name} to DM to owner")
+                        
+                        embed = discord.Embed(
+                            description=f"📉 Your fleet carrier {carrier.carrier_name} ({carrier.carrier_identifier}) is low on %s - %s remaining." 
+                                         % ( com['name'], com['stock'] ),
+                            color=constants.EMBED_COLOUR_WARNING
+                        )
+
+                        message = f"<@{carrier.carrier_owner}>: Your fleet carrier {carrier.carrier_name} ({carrier.carrier_identifier}) is low on %s - %s remaining.\n\n" \
+                                  f"*Please enable direct messages from <@{bot.user.id}> to receive these alerts via DM.*" % ( com['name'], com['stock'] )
+                        
+                        await notify_wmm_owner(carrier, embed, message)
+
+                        # tell the db we've notified for this commodity
+                        if not notification_status:
+                            notification_status = []
+
+                        notification_status.append(com['name'])
+                        carrier.notification_status = notification_status
+
+                        await _update_wmm_carrier(carrier)
+
+                # has stock, not low
+                else:
+                    wmm_stock[carrier.carrier_location].append("%s x %s - %s (%s) - **%s** - Price: %s %s" % (
+                        com['name'], format(com['stock'], ','), stn_data['currentStarSystem'].upper(), carrier.carrier_location, carrier_name, format(com['buyPrice'], ','), market_updated )
+                    )
+
+        # no stock at all
+        if not carrier_has_stock:
+            wmm_stock[carrier.carrier_location].append("**%s** - %s (%s) has no stock of any WMM commodity! %s" % (
+                carrier_name, stn_data['currentStarSystem'].upper(), carrier.carrier_location, market_updated )
+            )
+
+    for system in wmm_systems:
+        content[system] = []
+        content[system].append('-')
+        if system not in wmm_stock:
+            content[system].append("Could not find any carriers with stock in %s" % system)
+        else:
+            for line in wmm_stock[system]:
+                content[system].append(line)
+
+    try:
+        wmm_updated = "<t:%d:R>" % datetime.now().timestamp()
+    except:
+        wmm_updated = datetime.now().strftime("%d %b %Y %H:%M:%S")
+        pass
+
+    # clear message history
+    await clear_history(wmm_channel)
+
+    # for each station, use a new message.
+    # and split messages over 10 lines.
+    # each line is between 120-200 chars
+    # using max: 2000 / 200 = 10
+    for (system, stncontent) in content.items():
+        if len(stncontent) == 1:
+            # this station has no carriers, dont bother printing it.
+            continue
+        pages = [page for page in chunk(stncontent, 10)]
+        for page in pages:
+            page.insert(0, ':')
+            await wmm_channel.send('\n'.join(page))
+
+    footer = []
+    footer.append(':')
+    footer.append("-\nCarrier stocks last checked %s" % ( wmm_updated ))
+    footer.append("Carriers with no timestamp are fetched from cAPI and are accurate to within an hour.")
+    footer.append("Carriers with (As of ...) are fetched from Inara. Ensure EDMC is running to update stock levels!")
+    await wmm_channel.send('\n'.join(footer))
+
+    print("Current list of stations:")
+    print(wmm_station_stock)
+
+    for system in wmm_station_stock:
+        ccocontent[system] = []
+        for station in wmm_station_stock[system]:
+            ccocontent[system].append('-')
+            for commodity in commodities_wmm:
+                if commodity.lower() not in wmm_station_stock[system][station]:
+                    ccocontent[system].append(f"{commodity.title()} x NO STOCK !! - {system} ({station})")
+                else:
+                    ccocontent[system].append(f"{commodity.title()} x {format(wmm_station_stock[system][station][commodity.lower()], ',')} - {system} ({station})")
+
+    # for each station, use a new message.
+    # and split messages over 10 lines.
+    # each line is roughly 50 chars
+    # using max: 2000 / 50 = 40
+    await clear_history(ccochannel)
+    for (system, stncontent) in ccocontent.items():
+        if len(stncontent) == 1:
+            # this station has no carriers, dont bother printing it.
+            continue
+        pages = [page for page in chunk(stncontent, 40)]
+        for page in pages:
+            page.insert(0, ':')
+            await ccochannel.send('\n'.join(page))
+
+    # the following code allows us to change sleep time dynamically
+    # waiting at least 10 seconds before checking constants.wmm_interval again
+    # This also checks for the trigger to manually update.
+    constants.wmm_slept_for = 0
+    while constants.wmm_slept_for < constants.wmm_interval:
+        # wmm_trigger is set by ;wmm_stock command
+        if constants.wmm_trigger:
+            print("Manual WMM stock refresh triggered.")
+            constants.wmm_trigger = False
+            constants.wmm_slept_for = constants.wmm_interval
+        else:
+            await asyncio.sleep(10)
+            constants.wmm_slept_for = constants.wmm_slept_for + 10
+
+@wmm_stock.after_loop
+async def wmm_after_loop():
+    if not wmm_stock.is_running() or wmm_stock.failed():
+        print("wmm_stock after_loop(). task has failed.\n")
+
+@wmm_stock.error
+async def wmm_stock_error(error):
+    if not wmm_stock.is_running() or wmm_stock.failed():
+        print("wmm_stock error(). task has failed.\n")
+    traceback.print_exc()

--- a/ptn/missionalertbot/modules/Embeds.py
+++ b/ptn/missionalertbot/modules/Embeds.py
@@ -321,3 +321,16 @@ def dm_forbidden_embed(user: discord.Member):
         color=constants.EMBED_COLOUR_QU
     )
     return embed
+
+
+# Orphaned carriers summary embed
+def orphaned_carrier_summary_embed(summary_text):
+    embed = discord.Embed(
+        title="🔎 ORPHANED FLEET CARRIERS",
+        description="The following Fleet Carriers' owners could not be resolved and are likely not present on the server. Note **occasionally member lookups can fail for valid members**.\n\n"
+                    f"{summary_text}\n\n"
+                    "`✗ Cancel` to do nothing\n`❕ Exclude Carriers` to temporarily exclude carriers from purging using their DBIDs as listed above\n"
+                    "`✔ Purge Listed Carriers` to **permanently** delete all carriers listed above from the database.",
+        color=constants.EMBED_COLOUR_QU
+    )
+    return embed

--- a/ptn/missionalertbot/modules/Embeds.py
+++ b/ptn/missionalertbot/modules/Embeds.py
@@ -3,6 +3,14 @@ A module containing embeds that are required by multiple functions.
 
 STATUS: This file is complete, but needs to be imported into modules that use it
 """
+import sys
+
+if __name__ == "__main__":
+    # Prevent accidental independent execution of this file 
+    print("This script should not be run independently. Please run it through application.py.")
+    # Exit the script with an error code
+    sys.exit(1)
+
 
 # import libraries
 import os
@@ -23,7 +31,6 @@ from ptn.missionalertbot.constants import ptn_logo_discord
 
 #import local modules
 from ptn.missionalertbot.database.database import find_mission
-
 
 # confirm edit mission embed
 def _confirm_edit_mission_embed(mission_params: MissionParams):
@@ -115,10 +122,11 @@ async def _configure_all_carrier_detail_embed(embed, carrier_data: CarrierData):
     """
     embed.add_field(name='Carrier Name', value=f'{carrier_data.carrier_long_name}', inline=True)
     embed.add_field(name='Carrier Identifier', value=f'{carrier_data.carrier_identifier}', inline=True)
-    embed.add_field(name='Short Name', value=f'{carrier_data.carrier_short_name}', inline=True)
+    # embed.add_field(name='Short Name', value=f'{carrier_data.carrier_short_name}', inline=True)
     embed.add_field(name='Discord Channel', value=f'#{carrier_data.discord_channel}', inline=True)
     embed.add_field(name='Carrier Owner', value=f'<@{carrier_data.ownerid}>', inline=True)
     embed.add_field(name='DB ID', value=f'{carrier_data.pid}', inline=True)
+    embed.add_field(name='Frontier API', value='✅ Enabled' if carrier_data.capi else 'Disabled', inline=True)
     embed.set_footer(text="Note: DB ID is not an editable field.")
     return embed
 
@@ -147,7 +155,7 @@ async def _generate_cc_notice_embed(channel_id, user, avatar, title, message, im
     return embed, thumb_file
 
 # add common embed fields for carrier info
-def _add_common_embed_fields(embed, carrier_data, ctx_interaction):
+def _add_common_embed_fields(embed, carrier_data: CarrierData, ctx_interaction):
     embed.add_field(name="Carrier Name", value=f"{carrier_data.carrier_long_name}", inline=True)
     embed.add_field(name="Carrier ID", value=f"{carrier_data.carrier_identifier}", inline=True)
     embed.add_field(name="Database Entry", value=f"{carrier_data.pid}", inline=True)
@@ -158,7 +166,7 @@ def _add_common_embed_fields(embed, carrier_data, ctx_interaction):
     embed.add_field(name="Discord Channel", value=f"{discord_channel}", inline=True)
 
     embed.add_field(name="Owner", value=f"<@{carrier_data.ownerid}>", inline=True)
-    embed.add_field(name="Market Data", value=f"`;stock {carrier_data.carrier_short_name}`", inline=True)
+    embed.add_field(name="Frontier API", value="✅ Enabled" if carrier_data.capi else "Disabled", inline=True)
     embed.add_field(name="Last Trade", value=f"<t:{carrier_data.lasttrade}> (<t:{carrier_data.lasttrade}:R>)", inline=True)
     # shortname is not relevant to users and will be auto-generated in future
     return embed
@@ -331,6 +339,14 @@ def orphaned_carrier_summary_embed(summary_text):
                     f"{summary_text}\n\n"
                     "`✗ Cancel` to do nothing\n`❕ Exclude Carriers` to temporarily exclude carriers from purging using their DBIDs as listed above\n"
                     "`✔ Purge Listed Carriers` to **permanently** delete all carriers listed above from the database.",
+        color=constants.EMBED_COLOUR_QU
+    )
+    return embed
+
+# generic "please wait" embed
+def please_wait_embed():
+    embed = discord.Embed(
+        description="⏳ Please wait a moment...",
         color=constants.EMBED_COLOUR_QU
     )
     return embed

--- a/ptn/missionalertbot/modules/Embeds.py
+++ b/ptn/missionalertbot/modules/Embeds.py
@@ -15,6 +15,7 @@ import discord
 # import local classes
 from ptn.missionalertbot.classes.CarrierData import CarrierData
 from ptn.missionalertbot.classes.CommunityCarrierData import CommunityCarrierData
+from ptn.missionalertbot.classes.MissionParams import MissionParams
 
 # import local constants
 import ptn.missionalertbot.constants as constants
@@ -22,6 +23,25 @@ from ptn.missionalertbot.constants import ptn_logo_discord
 
 #import local modules
 from ptn.missionalertbot.database.database import find_mission
+
+
+# confirm edit mission embed
+def _confirm_edit_mission_embed(mission_params: MissionParams):
+    """
+    Used by mission editor to confirm details with user before committing.
+
+    Param mission_params: ClassInstance of MissionParams
+    """
+    confirm_embed = discord.Embed(
+        title=f"{mission_params.mission_type.upper()}ING: {mission_params.carrier_data.carrier_long_name}",
+        description=f"Please confirm updated mission details for {mission_params.carrier_data.carrier_long_name}:\n\n" \
+                    f"{mission_params.discord_text}",
+        color=constants.EMBED_COLOUR_QU
+    )
+    thumb_url = constants.ICON_LOADING if mission_params.mission_type == 'load' else constants.ICON_UNLOADING
+    confirm_embed.set_thumbnail(url=thumb_url)
+
+    return confirm_embed
 
 
 # return an embed featuring either the active mission or the not found message

--- a/ptn/missionalertbot/modules/MissionCleaner.py
+++ b/ptn/missionalertbot/modules/MissionCleaner.py
@@ -11,6 +11,7 @@ import aiohttp
 import asyncio
 import random
 from time import strftime
+import traceback
 
 # import discord.py
 import discord
@@ -370,6 +371,7 @@ async def remove_carrier_channel(interaction: discord.Interaction, completed_mis
             return
 
     except Exception as e:
+        traceback.print_exc()
         try:
             error = f"Unable to delete carrier channel: {e}"
             raise CustomError(error)

--- a/ptn/missionalertbot/modules/MissionCleaner.py
+++ b/ptn/missionalertbot/modules/MissionCleaner.py
@@ -211,7 +211,7 @@ async def _cleanup_completed_mission(interaction: discord.Interaction, mission_d
             # command feedback
             print("Log usage in bot spam")
             spamchannel = bot.get_channel(bot_spam_channel())
-            reason = f"\n\nReason given: `{message}`" if not message == None else ""
+            reason = f"\n\nReason given: `{message}`" if not message == None else "" # TODO what the unholy fuck is this Sihmm
             embed = discord.Embed(title=f"Mission {status} for {mission_data.carrier_name}",
                                 description=f"<@{interaction.user.id}> reported in <#{interaction.channel.id}> ({interaction.channel.name}).{reason}",
                                 color=constants.EMBED_COLOUR_OK)
@@ -220,7 +220,7 @@ async def _cleanup_completed_mission(interaction: discord.Interaction, mission_d
 
             if cco: # tells us whether /cco complete was used or /mission complete
                 print("Send feedback to the CCO")
-                message_text = f':\n>>>{message}' if message else ''
+                message_text = f':\nReason given: `{message}`' if message else ''
                 feedback_embed = discord.Embed(
                     description=f"{emoji} **MISSION {status.upper()}** for **{mission_data.carrier_name}**{message_text}",
                     color=constants.EMBED_COLOUR_OK

--- a/ptn/missionalertbot/modules/MissionEditor.py
+++ b/ptn/missionalertbot/modules/MissionEditor.py
@@ -261,7 +261,7 @@ async def edit_active_mission(interaction: discord.Interaction, mission_params, 
         description=f"Please confirm updated mission details for {mission_params.carrier_data.carrier_long_name}.",
         color=constants.EMBED_COLOUR_QU
     )
-    thumb_url = constants.ICON_FC_LOADING if mission_params.mission_type == 'load' else constants.ICON_FC_UNLOADING
+    thumb_url = constants.ICON_LOADING if mission_params.mission_type == 'load' else constants.ICON_UNLOADING
     confirm_embed.set_thumbnail(url=thumb_url)
 
     confirm_embed = _mission_summary_embed(mission_params, confirm_embed)

--- a/ptn/missionalertbot/modules/MissionEditor.py
+++ b/ptn/missionalertbot/modules/MissionEditor.py
@@ -325,8 +325,11 @@ async def edit_discord_alerts(interaction: discord.Interaction, mission_params: 
                 try:
                     print("Send new alert")
                     alerts_channel, submit_mission = await send_discord_alert(interaction, mission_params)
+
+                    discord_alert_msg = await alerts_channel.fetch_message(mission_params.discord_alert_id)
+
                     embed = discord.Embed(
-                        description=f"Original alert not found. Replacement sent to <#{alerts_channel.id}>",
+                        description=f"Original alert not found. Replacement sent to {discord_alert_msg.jump_url}",
                         color=constants.EMBED_COLOUR_WARNING
                     )
                     await interaction.channel.send(embed=embed)

--- a/ptn/missionalertbot/modules/MissionEditor.py
+++ b/ptn/missionalertbot/modules/MissionEditor.py
@@ -287,13 +287,18 @@ async def edit_discord_alerts(interaction: discord.Interaction, mission_params: 
     async with interaction.channel.typing():
         try:
             # find alerts channel
-            if mission_params.booze_cruise:
+            if hasattr(mission_params, "booze_cruise"): # missions from 2.3.0 have this attribute
+                # 2.3.0 stores alerts channel used in params so we don't have to figure it out, just retrieve it
+                alerts_channel = bot.get_channel(mission_params.channel_alerts_actual)
+
+            elif mission_params.commodity_name.title() == 'Wine': # pre-2.3.0 wine missions always went to cellar
                 if mission_params.mission_type == 'load':
                     alerts_channel = bot.get_channel(mission_params.channel_defs.wine_loading_channel_actual)
                 else:   # unloading block
                     alerts_channel = bot.get_channel(mission_params.channel_defs.wine_unloading_channel_actual)
-            else:
-                alerts_channel = bot.get_channel(mission_params.channel_defs.alerts_channel_actual)
+
+            else: # pre-2.3.0 non-wine loads
+                alerts_channel = bot.get_channel(mission_params.channel_defs.alerts_channel_actual)            
 
             print(alerts_channel)
             print(mission_params.discord_alert_id)
@@ -309,14 +314,20 @@ async def edit_discord_alerts(interaction: discord.Interaction, mission_params: 
             # get new trade alert message
             print("Create new alert text and embed")
             mission_params.discord_text = txt_create_discord(interaction, mission_params)
-            if not mission_params.booze_cruise:
+            if hasattr(mission_params, "booze_cruise"): # pre-2.3.0 backwards compatibility
+                if not mission_params.booze_cruise:
+                    embed = await return_discord_alert_embed(interaction, mission_params)
+            else:
                 embed = await return_discord_alert_embed(interaction, mission_params)
 
             # edit in new trade alert message
             if discord_alert_msg:
                 try:
                     print("Edit alert message")
-                    await discord_alert_msg.edit(content=mission_params.discord_text, suppress=True) if mission_params.booze_cruise else await discord_alert_msg.edit(embed=embed) 
+                    if hasattr(mission_params, "booze_cruise"): # pre-2.3.0 backwards compatibility
+                        await discord_alert_msg.edit(content=mission_params.discord_text, suppress=True) if mission_params.booze_cruise else await discord_alert_msg.edit(embed=embed) 
+                    else:
+                        await discord_alert_msg.edit(embed=embed) 
                 except Exception as e:
                     print(e)
                     embed=discord.Embed(description=f"Error editing discord alert: {e}", color=constants.EMBED_COLOUR_ERROR)
@@ -364,8 +375,11 @@ async def edit_discord_alerts(interaction: discord.Interaction, mission_params: 
                 print("Checking for cco_message_text status...")
                 if mission_params.cco_message_text is not None: send_embeds.append(discord_embeds.owner_text_embed)
 
-                if mission_params.notify_msg_id:
-                    ping_role_id = wineloader_role() if mission_params.commodity_name == 'Wine' else hauler_role()
+                if mission_params.notify_msg_id: 
+                    if hasattr(mission_params, "booze_cruise"): # 2.3.0+
+                        ping_role_id = mission_params.role_ping_actual
+                    else: # pre-2.3.0 compatibility
+                        ping_role_id = wineloader_role() if mission_params.commodity_name.title == 'Wine' else hauler_role()
                     await discord_notify_msg.edit(content=f"<@&{ping_role_id}>: {mission_params.discord_text}")
 
                 print("Checking mission_type status...")

--- a/ptn/missionalertbot/modules/MissionGenerator.py
+++ b/ptn/missionalertbot/modules/MissionGenerator.py
@@ -1261,7 +1261,7 @@ async def gen_mission(interaction: discord.Interaction, mission_params: MissionP
                 if not submit_mission: # error condition, cleanup after ourselves
                     cleanup_temp_image_file(mission_params.discord_img_name)
                     if mission_params.mission_temp_channel_id:
-                        await remove_carrier_channel(interaction, mission_params.mission_temp_channel_id, seconds_short)
+                        await remove_carrier_channel(interaction, mission_params.mission_temp_channel_id, seconds_short())
 
             if "r" in mission_params.sendflags and not mission_params.edmc_off: # send to subreddit
                 async with interaction.channel.typing():
@@ -1356,7 +1356,7 @@ async def gen_mission(interaction: discord.Interaction, mission_params: MissionP
         except Exception as e:
             print(e)
         if mission_params.mission_temp_channel_id:
-            await remove_carrier_channel(interaction, mission_params.mission_temp_channel_id, seconds_short)
+            await remove_carrier_channel(interaction, mission_params.mission_temp_channel_id, seconds_short())
 
 
 async def create_mission_temp_channel(interaction, mission_params):
@@ -1571,13 +1571,11 @@ async def mission_generation_complete(interaction: discord.Interaction, mission_
     embed = discord.Embed(
         title=f"{mission_data.mission_type.upper()}ING {mission_data.carrier_name} ({mission_data.carrier_identifier})",
         description="Mission successfully entered into the missions database. You can use `/missions` to view a list of active missions" \
-                   f" or `/mission information` in <#{mission_data.channel_id}> to view its mission information from the database.",
+                   f" or `/mission information` in <#{mission_data.channel_id}> to view its mission information from the database.\n\n" \
+                   f"{mission_data.mission_params.discord_text}",
         color=embed_colour
     )
     embed.set_thumbnail(url=thumbnail_url)
-
-    # update the embed with mission data fields
-    embed = _mission_summary_embed(mission_data.mission_params, embed)
 
     embed.set_footer(text="You can use /cco complete <carrier> to mark the mission complete.")
 

--- a/ptn/missionalertbot/modules/MissionGenerator.py
+++ b/ptn/missionalertbot/modules/MissionGenerator.py
@@ -179,10 +179,6 @@ class MissionSendView(View):
         button.disabled=True
         print(f"▶ {interaction.user.display_name} is sending their mission with flags {self.mission_params.sendflags}")
 
-        # this isn't really necessary but it's tidier
-        if not self.mission_params.webhook_names:
-            self.mission_params.sendflags.remove('w')
-
         try: # there's probably a better way to do this using an if statement
             self.clear_items()
             await interaction.response.edit_message(embeds=self.mission_params.original_message_embeds, view=self)

--- a/ptn/missionalertbot/modules/MissionGenerator.py
+++ b/ptn/missionalertbot/modules/MissionGenerator.py
@@ -1179,7 +1179,7 @@ async def prepare_for_gen_mission(interaction: discord.Interaction, mission_para
         winechannel = bot.get_channel(mission_params.channel_defs.wine_loading_channel_actual)
         role_to_check = discord.utils.get(interaction.guild.roles, id=pilot_role())
         print(f"⏳ Checking permissions for role {role_to_check}")
-        mission_params.booze_cruise = winechannel.permissions_for(interaction.guild.default_role).view_channel
+        mission_params.booze_cruise = winechannel.permissions_for(role_to_check).view_channel
         print(f"▶ BC status: {mission_params.booze_cruise}")
         # this only returns true if commodity is wine AND the BC channels are open, otherwise it is false
 

--- a/ptn/missionalertbot/modules/MissionGenerator.py
+++ b/ptn/missionalertbot/modules/MissionGenerator.py
@@ -481,9 +481,13 @@ async def return_discord_channel_embeds(mission_params: MissionParams):
 
     print("Define sell embed")
     # desc used by the local PTN additional info embed
+    if constants.commandid_stock:
+        stock_string = f"</stock:{constants.commandid_stock}>"
+    else:
+        stock_string = "`/stock`"
     additional_info_description = f"💎 Carrier Owner: <@{carrier_data.ownerid}>" \
                                   f"\n🔤 Carrier information: </info:849040914948554766>" \
-                                  f"\n📊 Stock information: `;stock {carrier_data.carrier_short_name}`\n\n"
+                                  f"\n📊 Stock information: {stock_string}\n\n"
 
     print("Define help embed (local)")
     # desc used by the local PTN help embed
@@ -1437,7 +1441,7 @@ async def create_mission_temp_channel(interaction, owner: discord.Member, missio
     else:
         # channel does not exist, create it
 
-        topic = f"Use \";stock {mission_params.carrier_data.carrier_short_name}\" to retrieve stock levels for this carrier."
+        topic = f"Use '/stock' to retrieve stock levels for this carrier."
 
         category = discord.utils.get(interaction.guild.categories, id=mission_params.channel_defs.category_actual)
         mission_temp_channel = await interaction.guild.create_text_channel(mission_params.carrier_data.discord_channel, category=category, topic=topic)

--- a/ptn/missionalertbot/modules/MissionGenerator.py
+++ b/ptn/missionalertbot/modules/MissionGenerator.py
@@ -34,7 +34,7 @@ from ptn.missionalertbot.classes.MissionParams import MissionParams
 import ptn.missionalertbot.constants as constants
 from ptn.missionalertbot.constants import bot, get_reddit, seconds_short, upvote_emoji, hauler_role, trainee_role, reddit_timeout, \
     get_guild, get_overwrite_perms, ptn_logo_discord, wineloader_role, o7_emoji, bot_spam_channel, discord_emoji, training_cat, \
-    trade_cat, mcomplete_id, somm_role
+    trade_cat, mcomplete_id, somm_role, pilot_role
 
 # import local modules
 from ptn.missionalertbot.database.database import backup_database, mission_db, missions_conn, find_carrier, CarrierDbFields, \
@@ -1175,8 +1175,12 @@ async def prepare_for_gen_mission(interaction: discord.Interaction, mission_para
     print(f"define_commodity returnflag status: {mission_params.returnflag}")
 
     if mission_params.commodity_name.title() == 'Wine':
+        print(f"⏳ Wine load detected, checking BC status by permissions for {mission_params.channel_defs.wine_loading_channel_actual}")
         winechannel = bot.get_channel(mission_params.channel_defs.wine_loading_channel_actual)
+        role_to_check = discord.utils.get(interaction.guild.roles, id=pilot_role())
+        print(f"⏳ Checking permissions for role {role_to_check}")
         mission_params.booze_cruise = winechannel.permissions_for(interaction.guild.default_role).view_channel
+        print(f"▶ BC status: {mission_params.booze_cruise}")
         # this only returns true if commodity is wine AND the BC channels are open, otherwise it is false
 
     # add any webhooks to mission_params

--- a/ptn/missionalertbot/modules/MissionGenerator.py
+++ b/ptn/missionalertbot/modules/MissionGenerator.py
@@ -1259,10 +1259,7 @@ async def gen_mission(interaction: discord.Interaction, mission_params: MissionP
 
         if "d" in mission_params.sendflags: # send to discord and save to mission database
             async with interaction.channel.typing():
-                try:
-                    submit_mission, mission_temp_channel = await send_mission_to_discord(interaction, mission_params)
-                except:
-                    print("Error during send_mission_to_discord()")
+                submit_mission, mission_temp_channel = await send_mission_to_discord(interaction, mission_params)
                 if not submit_mission: # error condition, cleanup after ourselves
                     cleanup_temp_image_file(mission_params.discord_img_name)
                     if mission_params.mission_temp_channel_id:
@@ -1446,6 +1443,7 @@ async def create_mission_temp_channel(interaction, mission_params):
         member = await guild.fetch_member(mission_params.carrier_data.ownerid)
         print(f"Owner identified as {member.display_name}")
     except:
+        print("Error resolving Discord member from owner")
         raise EnvironmentError(f'Could not find Discord user matching ID {mission_params.carrier_data.ownerid}')
 
     overwrite = await get_overwrite_perms()

--- a/ptn/missionalertbot/modules/StockHelpers.py
+++ b/ptn/missionalertbot/modules/StockHelpers.py
@@ -1,0 +1,192 @@
+"""
+A module for helper functions specifically for the Stock Tracker function.
+
+Depends on: constants, ErrorHandler
+
+"""
+
+# import libraries
+import json
+from bs4 import BeautifulSoup
+import requests
+import traceback
+
+# import discord.py
+import discord
+from discord import Forbidden
+
+# import local classes
+from ptn.missionalertbot.classes.CarrierData import CarrierData
+from ptn.missionalertbot.classes.WMMData import WMMData
+
+# import local constants
+import ptn.missionalertbot.constants as constants
+from ptn.missionalertbot.constants import bot, API_TOKEN, API_HOST, channel_cco_wmm_talk
+
+# import local modules
+from ptn.missionalertbot.modules.ErrorHandler import CommandChannelError, CommandRoleError, CustomError, GenericError, on_generic_error
+
+
+def inara_find_fc_system(fcid):
+    #print("Searching inara for carrier %s" % ( fcid ))
+    URL = "https://inara.cz/elite/station-market/?search=%s" % (fcid)
+    try:
+        page = requests.get(URL, headers={'User-Agent': 'PTNStockBot'})
+        soup = BeautifulSoup(page.content, "html.parser")
+        header = soup.find_all("div", class_="headercontent")
+        header_info = header[0].find("h2")
+        carrier_system_info = header_info.find_all('a', href=True)
+        carrier = carrier_system_info[0].text
+        system = carrier_system_info[1].text
+
+        if fcid in carrier:
+            # print("Carrier: %s (stationid %s) is at system: %s" % (carrier.text, stationid['href'][9:-1], system))
+            return {'system': system, 'stationid': carrier_system_info[0]['href'][15:-1], 'full_name': carrier}
+        else:
+            print("Could not find exact match, aborting inara search")
+            return False
+    except Exception as e:
+        print("No results from inara for %s, aborting search. Error: %s" % (fcid, e))
+        return False
+
+
+def inara_fc_market_data(fcid):
+    print("Searching inara market data for station: %s " % ( fcid ))
+    try:
+        url = "https://inara.cz/elite/station-market/?search=%s" % (fcid)
+        print(url)
+        page = requests.get(url, headers={'User-Agent': 'PTNStockBot'})
+        soup = BeautifulSoup(page.content, "html.parser")
+        mainblock = soup.find_all('div', class_='mainblock')
+
+        # Find carrier and system info
+        header = soup.find_all("div", class_="headercontent")
+        header_info = header[0].find("h2")
+        carrier_system_info = header_info.find_all('a', href=True)
+        carrier = carrier_system_info[0].text
+        system = carrier_system_info[1].text
+
+        # Find market info
+        updated = soup.find("div", text="Market update").next_sibling.get_text()
+        # main_content = soup.find('div', class_="maincontent0")
+        table = mainblock[1].find('table')
+        tbody = table.find("tbody")
+        rows = tbody.find_all('tr')
+        marketdata = []
+        for row in rows:
+            rowclass = row.attrs.get("class") or []
+            if "subheader" in rowclass:
+                continue
+            cells = row.find_all("td")
+            rn = cells[0].get_text()
+            commodity = {
+                'id': rn,
+                'name': rn,
+                'sellPrice': int(cells[1].get_text().replace('-', '0').replace(',', '').replace(' Cr', '')),
+                'buyPrice': int(cells[3].get_text().replace('-', '0').replace(',', '').replace(' Cr', '')),
+                'demand': int(cells[2].get_text().replace('-', '0').replace(',', '')),
+                'stock': int(cells[4].get_text().replace('-', '0').replace(',', ''))
+            }
+            marketdata.append(commodity)
+        data = {}
+        data['name'] = system
+        data['currentStarSystem'] = system
+        data['full_name'] = carrier
+        data['sName'] = fcid
+        data['market_updated'] = updated
+        data['commodities'] = marketdata
+        print("✅ Success") if data else print("❌ Failed")
+        return data
+    except Exception as e:
+        print("Exception getting inara data for carrier: %s" % fcid)
+        print(e)
+        traceback.print_exc()
+        return False
+
+
+def capi_fc_market_data(fcid):
+    # get stocks from capi and format as inara data.
+    capi_response = capi(fcid)
+    if capi_response.status_code != 200:
+        print(f"Error from CAPI for {fcid}: {capi_response.status_code}")
+        return False
+    stn_data = capi_response.json()
+    if 'market' not in stn_data:
+        print(f"No market data for {fcid}")
+        return False
+    stn_data['name'] = stn_data['currentStarSystem']
+    stn_data['sName'] = fcid
+    stn_data['market_updated'] = 'cAPI'
+    if 'commodities' in stn_data['market']:
+        # remove commodity from list if it has name 'Drones'.
+        # this is a bug in the CAPI data.
+        # then sort by name alphabetically.
+        stn_data['commodities'] = sorted([c for c in stn_data['market']['commodities'] if c['name'] != 'Drones'], key=lambda d: d['name'])
+        print("✅ Success") if stn_data else print("❌ Failed")
+    return stn_data
+
+
+def get_fc_stock(fccode, source='inara'):
+    if source == 'inara':
+        print("⏳ Attempting to fetch inara stock data for %s", [ fccode ])
+        stn_data = inara_fc_market_data(fccode)
+        if not stn_data:
+            return False
+    elif source == 'capi':
+        print("⏳ Attempting to fetch capi stock data for %s", [ fccode ])
+        stn_data = capi_fc_market_data(fccode)
+        if not stn_data:
+            return False
+    return stn_data
+
+
+def oauth_new(carrierid, force=False):
+    pmeters = {'token': API_TOKEN}
+    if force:
+        pmeters['force'] = "true"
+    r = requests.get(f"{API_HOST}/generate/{carrierid}",params=pmeters)
+    return r
+
+
+def capi(carrierid, dev=False):
+    pmeters = {'token': API_TOKEN}
+    if dev:
+        pmeters['dev'] = "true"
+    r = requests.get(f"{API_HOST}/capi/{carrierid}",params=pmeters)
+    return r
+
+
+# function taken from FCMS
+def from_hex(mystr):
+    try:
+        return bytes.fromhex(mystr).decode('utf-8')
+    except TypeError:
+        return "Unregistered Carrier"
+    except ValueError:
+        return "Unregistered Carrier"
+    
+
+def chunk(chunk_list, max_size=10):
+    """
+    Take an input list, and an expected max_size.
+
+    :returns: A chunked list that is yielded back to the caller
+    :rtype: iterator
+    """
+    for i in range(0, len(chunk_list), max_size):
+        yield chunk_list[i:i + max_size]
+
+
+# notify WMM owner
+async def notify_wmm_owner(carrier_data: WMMData, embed, message):
+    # notify the owner
+    owner = await bot.fetch_user(carrier_data.carrier_owner)
+    try:
+        await owner.send(embed=embed)
+        print(f"Low stock DM sent to {owner}")
+    except Forbidden:
+        print(f"Unable to DM {owner}, error 403. Pinging in channel instead.")
+        # ping the owner in-channel
+        cco_channel = bot.get_channel(channel_cco_wmm_talk())
+        await cco_channel.send(message)
+

--- a/ptn/missionalertbot/modules/TextGen.py
+++ b/ptn/missionalertbot/modules/TextGen.py
@@ -23,15 +23,21 @@ TEXT GEN FUNCTIONS
 """
 
 
-def txt_create_discord(interaction: Interaction, mission_params: MissionParams):
-    discord_channel_id = mission_params.mission_temp_channel_id if mission_params.mission_temp_channel_id else mission_params.carrier_data.discord_channel
-    discord_channel = f"<#{discord_channel_id}>"
+def txt_create_discord(interaction: Interaction, mission_params: MissionParams, preview=False):
+    discord_channel_id = mission_params.mission_temp_channel_id if not preview else None
+    discord_channel = f"<#{discord_channel_id}>" if discord_channel_id else f"**#{mission_params.carrier_data.discord_channel}**"
+    emoji = f'<:loading_emoji:{constants.loading_emoji()}>' if mission_params.mission_type == 'load' else f'<:unloading_emoji:{constants.unloading_emoji()}>' 
+
     if hasattr(mission_params, "booze_cruise") and mission_params.booze_cruise: # pre-2.3.0 backwards compatibility
         print("Generating BC wine alert...")
         # **[Carriername (CAR-IDX)]** | @[Cmdr Name] | [Loading System]/[Loading Station] - **[Amount of Wine]k** :wine_glass:+ **[Amount of Tritium]**:oil: @[Purchase Price of Tritium above Gal Avg]k/t
+        if preview:
+            name_link = mission_params.carrier_data.carrier_long_name
+        else:
+            name_link = f"[{mission_params.carrier_data.carrier_long_name}](https://discord.com/channels/{interaction.guild.id}/{discord_channel_id})"
         discord_text = (
             f"{'**★ EDMC-OFF MISSION! ★** : ' if mission_params.edmc_off else ''}"
-            f"**[{mission_params.carrier_data.carrier_long_name}](https://discord.com/channels/{interaction.guild.id}/{discord_channel_id})** "
+            f"**{name_link}** "
             f"**({mission_params.carrier_data.carrier_identifier})** | "
             f" <@{mission_params.carrier_data.ownerid}> | {mission_params.system.title()}/{mission_params.station.title()} - "
             f"**{mission_params.demand}k :wine_glass:**"

--- a/ptn/missionalertbot/modules/TextGen.py
+++ b/ptn/missionalertbot/modules/TextGen.py
@@ -23,12 +23,19 @@ TEXT GEN FUNCTIONS
 """
 
 
-def txt_create_discord(interaction: Interaction, mission_params: MissionParams, preview=False):
+def txt_create_discord(interaction: Interaction, mission_params: MissionParams, preview=False, commodities_in_stock = None):
+    updated_stock_level = ""
+    if commodities_in_stock:
+        for commodity in commodities_in_stock: # placeholder code for when we have multiple commodities to deal with
+            posix_time = get_formatted_date_string()[2]
+            hammertime = f"<t:{posix_time}:R>"
+            updated_stock_level = f"({commodity['stock']} remaining as of {hammertime}) "
+
     discord_channel_id = mission_params.mission_temp_channel_id if not preview else None
     discord_channel = f"<#{discord_channel_id}>" if discord_channel_id else f"**#{mission_params.carrier_data.discord_channel}**"
     emoji = f'<:loading_emoji:{constants.loading_emoji()}>' if mission_params.mission_type == 'load' else f'<:unloading_emoji:{constants.unloading_emoji()}>' 
 
-    if hasattr(mission_params, "booze_cruise") and mission_params.booze_cruise: # pre-2.3.0 backwards compatibility
+    if mission_params.booze_cruise:
         print("Generating BC wine alert...")
         # **[Carriername (CAR-IDX)]** | @[Cmdr Name] | [Loading System]/[Loading Station] - **[Amount of Wine]k** :wine_glass:+ **[Amount of Tritium]**:oil: @[Purchase Price of Tritium above Gal Avg]k/t
         if preview:
@@ -40,7 +47,8 @@ def txt_create_discord(interaction: Interaction, mission_params: MissionParams, 
             f"**{name_link}** "
             f"**({mission_params.carrier_data.carrier_identifier})** | "
             f" <@{mission_params.carrier_data.ownerid}> | {mission_params.system.title()}/{mission_params.station.title()} - "
-            f"**{mission_params.demand}k :wine_glass:**"
+            f"**{mission_params.demand}k :wine_glass:** "
+            f"{updated_stock_level}"
             f"{mission_params.cco_message_text if mission_params.cco_message_text else ''}"
         )
     else:
@@ -51,7 +59,9 @@ def txt_create_discord(interaction: Interaction, mission_params: MissionParams, 
             f"{mission_params.commodity_name} "
             f"{'from' if mission_params.mission_type == 'load' else 'to'} **{mission_params.station.upper()}** station in system "
             f"**{mission_params.system.upper()}** : {mission_params.profit}k per unit profit : "
-            f"{mission_params.demand}k {'demand' if mission_params.mission_type == 'load' else 'supply'} : {mission_params.pads.upper()}-pads."
+            f"{mission_params.demand}k {'demand' if mission_params.mission_type == 'load' else 'supply'} "
+            f"{updated_stock_level}"
+            f": {mission_params.pads.upper()}-pads."
         )
 
     print(f"Defined discord trade alert text:")

--- a/ptn/missionalertbot/modules/TextGen.py
+++ b/ptn/missionalertbot/modules/TextGen.py
@@ -26,19 +26,19 @@ TEXT GEN FUNCTIONS
 def txt_create_discord(interaction: Interaction, mission_params: MissionParams):
     discord_channel_id = mission_params.mission_temp_channel_id if mission_params.mission_temp_channel_id else mission_params.carrier_data.discord_channel
     discord_channel = f"<#{discord_channel_id}>"
-    if hasattr(mission_params, "booze_cruise"): # pre-2.3.0 backwards compatibility
-        if mission_params.booze_cruise:
-            # **[Carriername (CAR-IDX)]** | @[Cmdr Name] | [Loading System]/[Loading Station] - **[Amount of Wine]k** :wine_glass:+ **[Amount of Tritium]**:oil: @[Purchase Price of Tritium above Gal Avg]k/t
-            discord_text = (
-                f"{'**★ EDMC-OFF MISSION! ★** : ' if mission_params.edmc_off else ''}"
-                f"**[{mission_params.carrier_data.carrier_long_name}](https://discord.com/channels/{interaction.guild.id}/{discord_channel_id})** "
-                f"**({mission_params.carrier_data.carrier_identifier})** | "
-                f" <@{mission_params.carrier_data.ownerid}> | {mission_params.system.title()}/{mission_params.station.title()} - "
-                f"**{mission_params.demand}k :wine_glass:**"
-                f"{mission_params.cco_message_text if mission_params.cco_message_text else ''}"
-            )
-
+    if hasattr(mission_params, "booze_cruise") and mission_params.booze_cruise: # pre-2.3.0 backwards compatibility
+        print("Generating BC wine alert...")
+        # **[Carriername (CAR-IDX)]** | @[Cmdr Name] | [Loading System]/[Loading Station] - **[Amount of Wine]k** :wine_glass:+ **[Amount of Tritium]**:oil: @[Purchase Price of Tritium above Gal Avg]k/t
+        discord_text = (
+            f"{'**★ EDMC-OFF MISSION! ★** : ' if mission_params.edmc_off else ''}"
+            f"**[{mission_params.carrier_data.carrier_long_name}](https://discord.com/channels/{interaction.guild.id}/{discord_channel_id})** "
+            f"**({mission_params.carrier_data.carrier_identifier})** | "
+            f" <@{mission_params.carrier_data.ownerid}> | {mission_params.system.title()}/{mission_params.station.title()} - "
+            f"**{mission_params.demand}k :wine_glass:**"
+            f"{mission_params.cco_message_text if mission_params.cco_message_text else ''}"
+        )
     else:
+        print("Generating trade alert...")
         discord_text = (
             f"{'**★ EDMC-OFF MISSION! ★** : ' if mission_params.edmc_off else ''}"
             f"{discord_channel} {'load' if mission_params.mission_type == 'load' else 'unload'}ing "
@@ -47,7 +47,9 @@ def txt_create_discord(interaction: Interaction, mission_params: MissionParams):
             f"**{mission_params.system.upper()}** : {mission_params.profit}k per unit profit : "
             f"{mission_params.demand}k {'demand' if mission_params.mission_type == 'load' else 'supply'} : {mission_params.pads.upper()}-pads."
         )
-    print("Defined discord trade alert text")
+
+    print(f"Defined discord trade alert text:")
+    print(discord_text)
     return discord_text
 
 

--- a/ptn/missionalertbot/modules/TextGen.py
+++ b/ptn/missionalertbot/modules/TextGen.py
@@ -26,16 +26,17 @@ TEXT GEN FUNCTIONS
 def txt_create_discord(interaction: Interaction, mission_params: MissionParams):
     discord_channel_id = mission_params.mission_temp_channel_id if mission_params.mission_temp_channel_id else mission_params.carrier_data.discord_channel
     discord_channel = f"<#{discord_channel_id}>"
-    if mission_params.booze_cruise:
-        # **[Carriername (CAR-IDX)]** | @[Cmdr Name] | [Loading System]/[Loading Station] - **[Amount of Wine]k** :wine_glass:+ **[Amount of Tritium]**:oil: @[Purchase Price of Tritium above Gal Avg]k/t
-        discord_text = (
-            f"{'**★ EDMC-OFF MISSION! ★** : ' if mission_params.edmc_off else ''}"
-            f"**[{mission_params.carrier_data.carrier_long_name}](https://discord.com/channels/{interaction.guild.id}/{discord_channel_id})** "
-            f"**({mission_params.carrier_data.carrier_identifier})** | "
-            f" <@{mission_params.carrier_data.ownerid}> | {mission_params.system.title()}/{mission_params.station.title()} - "
-            f"**{mission_params.demand}k :wine_glass:**"
-            f"{mission_params.cco_message_text if mission_params.cco_message_text else ''}"
-        )
+    if hasattr(mission_params, "booze_cruise"): # pre-2.3.0 backwards compatibility
+        if mission_params.booze_cruise:
+            # **[Carriername (CAR-IDX)]** | @[Cmdr Name] | [Loading System]/[Loading Station] - **[Amount of Wine]k** :wine_glass:+ **[Amount of Tritium]**:oil: @[Purchase Price of Tritium above Gal Avg]k/t
+            discord_text = (
+                f"{'**★ EDMC-OFF MISSION! ★** : ' if mission_params.edmc_off else ''}"
+                f"**[{mission_params.carrier_data.carrier_long_name}](https://discord.com/channels/{interaction.guild.id}/{discord_channel_id})** "
+                f"**({mission_params.carrier_data.carrier_identifier})** | "
+                f" <@{mission_params.carrier_data.ownerid}> | {mission_params.system.title()}/{mission_params.station.title()} - "
+                f"**{mission_params.demand}k :wine_glass:**"
+                f"{mission_params.cco_message_text if mission_params.cco_message_text else ''}"
+            )
 
     else:
         discord_text = (

--- a/ptn/missionalertbot/modules/helpers.py
+++ b/ptn/missionalertbot/modules/helpers.py
@@ -775,6 +775,18 @@ def flexible_carrier_search_term(search_term):
 
     return carrier_data
 
+# clear WMM channel
+async def clear_history(channel, limit=20):
+    try:
+        msgs = []
+        async for message in channel.history(limit=limit):
+            if message.author.name == bot.user.name:
+                msgs.append(message)
+        await channel.delete_messages(msgs)
+    except:
+        # discord doesn't let us delete history after 14 days, nothing we can do.
+        pass
+
 # presently unused
 # TODO: remove or incorporate
 def _get_id_from_mention(mention):

--- a/ptn/missionalertbot/modules/helpers.py
+++ b/ptn/missionalertbot/modules/helpers.py
@@ -167,6 +167,10 @@ def check_mission_channel_lock(channel):
         return False
 
 
+def list_active_locks():
+    return channel_locks
+
+
 # function to stop and quit
 def bot_exit():
     sys.exit("User requested exit.")

--- a/ptn/missionalertbot/modules/helpers.py
+++ b/ptn/missionalertbot/modules/helpers.py
@@ -196,6 +196,17 @@ def _regex_alphanumeric_with_hyphens(regex_string):
     print(f"Processed {regex_string} into {processed_string}")
     return processed_string
 
+def _regex_alphanumeric_only(regex_string):
+    # remove spaces and make lowercase
+    regex_string_no_spaces = regex_string.lower().replace(' ', '')
+    # take only the alphanumeric characters and hyphens, leave behind everything else
+    re_compile = re.compile('([\w-]+)')
+    compiled_name = re_compile.findall(regex_string_no_spaces)
+    # join together all the extracted bits into one string
+    processed_string = ''.join(compiled_name)
+    print(f"Processed {regex_string} into {processed_string}")
+    return processed_string
+
 
 """
 Community Team command helpers
@@ -708,7 +719,7 @@ def extract_carrier_ident_strings(message: discord.Message):
             print(f'Found matching pair in message: {ptn_string} ({bracket_string})')
             # extract a shortname
             shortname_string = re.sub(shortname_pattern, '', ptn_string)
-            shortname_string = shortname_string.lower().replace(" ", "")
+            shortname_string = _regex_alphanumeric_only(shortname_string)
 
             # create a channel name
             stripped_name = _regex_alphanumeric_with_hyphens(ptn_string).lower()

--- a/ptn/missionalertbot/modules/helpers.py
+++ b/ptn/missionalertbot/modules/helpers.py
@@ -9,7 +9,6 @@ Depends on: constants, ErrorHandler, database
 import asyncio
 from datetime import datetime, timezone
 import emoji
-from functools import wraps
 import random
 import re
 import sys
@@ -19,9 +18,9 @@ import discord
 from discord import Interaction, app_commands
 from discord.errors import HTTPException, Forbidden, NotFound
 from discord.ext import commands
-from discord.ui import View, Button
 
 # import local classes
+from ptn.missionalertbot.classes.ChannelDefs import ChannelDefs
 from ptn.missionalertbot.classes.CommunityCarrierData import CommunityCarrierData
 
 # import local constants
@@ -665,19 +664,6 @@ def convert_str_to_float_or_int(element: any) -> bool: # this code turns a STR i
         print(f"We can't float {element}")
         return False
 
-
-# a class to hold channel definitions for training mode
-class ChannelDefs:
-    def __init__(self, category_actual, alerts_channel_actual, mission_command_channel_actual, upvotes_channel_actual, wine_loading_channel_actual, wine_unloading_channel_actual, sub_reddit_actual, reddit_flair_in_progress, reddit_flair_completed):
-        self.category_actual = category_actual
-        self.alerts_channel_actual = alerts_channel_actual
-        self.mission_command_channel_actual = mission_command_channel_actual
-        self.upvotes_channel_actual = upvotes_channel_actual
-        self.wine_loading_channel_actual = wine_loading_channel_actual
-        self.wine_unloading_channel_actual = wine_unloading_channel_actual
-        self.sub_reddit_actual = sub_reddit_actual
-        self.reddit_flair_in_progress = reddit_flair_in_progress
-        self.reddit_flair_completed = reddit_flair_completed
 
 # check whether CCO command is being used in training or live categories
 def check_training_mode(interaction: discord.Interaction):

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         ],
     description='Pilots Trade Network Mission Alert Bot',
     long_description=long_description,
-    author='Charles Tosh',
+    author='Charlie Tosh',
     url='',
     install_requires=[
         # 'aiohttp==3.7.4.post0',
@@ -58,7 +58,9 @@ setup(
         'asyncpraw==7.7.0',
         'asyncprawcore==2.3.0',
         'python-dateutil>=2.8.1',
-        'emoji>=2.2.0'
+        'emoji>=2.2.0',
+        'bs4>=0.0.1',
+        'texttable>=1.6.4'
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'discord.py>=2.3.0',
         # 'idna==3.1',
         # 'multidict==5.1.0',
-        'Pillow==10.0.1',
+        'Pillow==10.2.0',
         'python-dotenv==0.15.0',
         # 'pytz==2021.1',
         'typing-extensions==3.7.4.3',


### PR DESCRIPTION
## 2.4.0
Integrated stock tracking features from stockbot (with thanks to DudeInCorner and Durzo):
- `/stock`:
 - can be used in a carrier channel without parameters to check stock of that carrier.
 - can be used with carrier as a parameter to check stock for any carrier.
 - can optionally specify inara or capi as source; default is capi.
 - added information in footer as to stock source.
 - EDMC data notice is now context-sensitive:
   - EDMC notice will only show when source is 'inara'.
   - EDMC-off missions will show a reminder to disable EDMC, instead of the reminder to use it
- `/cco capi enable`: If capi auth is confirmed, will flag the carrier(s) as capi-enabled; otherwise, will send the target carrier owner a DM with OAuth link and explanation. Multiple carriers can be separated by commas.
- `/cco capi disable`: Will flag the carrier(s) as capi-disabled and prevent capi stock checks. Multiple carriers can be separated by commas.
- Adding carriers to Mission Alert Bot will no longer prompt the user to add to stockbot.

Integrated WMM tracking features from stockbot (with thanks to Durzo):
- WMM stock display in #wmm-stock and #cco-wmm-supplies.
- `/cco wmm enable`: Adds a carrier to WMM tracking; option to autocomplete station location from list.
- `/cco wmm disable`: Removes one or more carriers from WMM tracking. Multiple carriers can be separated by commas.
- `/cco wmm update`: Trigger manual refresh of all WMM stock.
- `/admin wmm status`: Check the status of the WMM background task; now shows time remaining until next loop, as well as current interval time.
- `/admin wmm stop`: Stop the WMM background task.
- `/admin wmm start`: Start or restart the WMM background task.
- `/admin wmm interval`: Set the WMM update interval in minutes.
- `m.wmm_list`: List active WMM carriers.

Other:
- `/carrier add` and `Add Carrier` no longer offer StockBot code for `;add_FC`.
- `/carrier add` no longer has a shortname field; all shortnames are now generated internally by MAB.
- `/carrier add` can now be used in #CCO-general-chat
- Changed references to `;stock <shortname>` to `/stock`.
- Removed shortname as a user-facing variable.
- Added cAPI status to carrier info embeds.
- Trade Alerts will now include updated supply/demand remaining if a user uses `/stock` for a carrier on a mission.
- Updated web links for loading/unloading images so Discord will finally stock mocking me with cached images from 3 months ago.
- `/admin capi_sync`: Intended for first run after StockBot migration: updates CAPI status for all registered PTN Fleet Carriers.
- Added initial `settings.txt` with option to disable WMM auto start and specific some command IDs; for now, only `/stock` is implemented:
 - `/admin settings view` to view settings.txt;
 - `/admin settings change` to change a setting in the file.

Fixes #640 